### PR TITLE
fix: settings backup loop and profile crop initial size

### DIFF
--- a/apps/web/src/features/settings/components/EditUserModalForm.tsx
+++ b/apps/web/src/features/settings/components/EditUserModalForm.tsx
@@ -103,10 +103,9 @@ export function ProfileImageModal({
     defaultValues: { profilePhoto: ppIn },
   });
   const [crop, setCrop] = useState<any>({
-    unit: 'px',
-    aspect: 1 / 1,
-    x: 5,
-    y: 5,
+    unit: '%',
+    x: 0,
+    y: 0,
     width: 100,
     height: 100,
   });

--- a/apps/web/src/features/settings/components/UserDataSettingsGroup.tsx
+++ b/apps/web/src/features/settings/components/UserDataSettingsGroup.tsx
@@ -129,9 +129,9 @@ export function UserDataSettingsGroup() {
 
   useEffect(() => {
     if (backupFile) {
-      formref.current?.dispatchEvent(new Event('submit', { cancelable: true }));
+      handleSubmit(importData)();
     }
-  }, [backupFile]);
+  }, [backupFile, handleSubmit, importData]);
 
   useEffect(() => {
     if (checkIfPersistentStorageAvailable()) {


### PR DESCRIPTION
UserDataSettingsGroup: dispatchEvent('submit') bypasses react-hook-form's preventDefault, causing GET submission to /settings?backup= and a reload loop. Call handleSubmit(importData)() directly instead.

EditUserModalForm: crop initialized at 100x100px regardless of image size, appearing as a small square in the corner. Switch to 100% unit so the selection covers the full image by default.

Closes #331
Closes #332