### PR TITLE
feat: update epic r4 endpoints

### DIFF
--- a/libs/epic/.env.example
+++ b/libs/epic/.env.example
@@ -1,2 +1,3 @@
 DSTU2_ENDPOINTS_URL=https://open.epic.com/Endpoints/DSTU2
+R4_ENDPOINTS_URL=https://open.epic.com/Endpoints/R4
 R4_BRANDS_ENDPOINT_URL=https://open.epic.com/Endpoints/Brands

--- a/libs/epic/src/lib/data/R4Endpoints.json
+++ b/libs/epic/src/lib/data/R4Endpoints.json
@@ -24,6 +24,14 @@
     "managingOrganization": "Access Community Health Network"
   },
   {
+    "url": "https://epicproxy.et1439.epichosted.com/FHIRProxyPRD/api/FHIR/R4/",
+    "id": "63eb7da5-8e5f-48e6-b397-bae783fcf53a",
+    "name": "Access Health",
+    "token": "https://epicproxy.et1439.epichosted.com/FHIRProxyPRD/oauth2/token",
+    "authorize": "https://epicproxy.et1439.epichosted.com/FHIRProxyPRD/oauth2/authorize",
+    "managingOrganization": "Avera Health"
+  },
+  {
     "url": "https://epicproxy.et1041.epichosted.com/FHIRProxy/api/FHIR/R4/",
     "id": "287c5edb-b6f7-4f3e-a344-ef11d9283590",
     "name": "Acumen Physician Solutions",
@@ -40,19 +48,19 @@
     "managingOrganization": "Parkview Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartAdaptIHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTADAPTIHC/api/FHIR/R4/",
     "id": "1668558c-b845-4036-b3b4-c50596f0d09f",
     "name": "Adapt Integrated Health Care",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartAdaptIHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartAdaptIHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTADAPTIHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTADAPTIHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartAdvanceCH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTADVANCECH/api/FHIR/R4/",
     "id": "7d891b5e-e67d-4ea8-897a-92ede0eb019b",
     "name": "Advance Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartAdvanceCH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartAdvanceCH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTADVANCECH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTADVANCECH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -112,11 +120,11 @@
     "managingOrganization": "Advocate-Aurora"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartagape/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTAGAPE/api/FHIR/R4/",
     "id": "cba7f34a-ce05-47c7-8ea7-77bb82badc11",
     "name": "Agape Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartagape/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartagape/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTAGAPE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTAGAPE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -152,11 +160,11 @@
     "managingOrganization": "HCA"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartach/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTACH/api/FHIR/R4/",
     "id": "f7c24a9f-2534-4be9-89fb-b8c9c798dedd",
     "name": "Albany County Department of Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartach/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartach/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTACH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTACH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -176,11 +184,11 @@
     "managingOrganization": "UC San Diego Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/allcarehealthcenter/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/ALLCAREHEALTHCENTER/api/FHIR/R4/",
     "id": "7bb34812-5c25-49ab-ab05-0ee46cef7b51",
     "name": "All Care Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/allcarehealthcenter/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/allcarehealthcenter/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/ALLCAREHEALTHCENTER/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/ALLCAREHEALTHCENTER/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -200,12 +208,20 @@
     "managingOrganization": "Allegheny Health Network"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartAMC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTAMC/api/FHIR/R4/",
     "id": "236ae815-19d2-404b-96ca-31947344b82b",
     "name": "Alliance Medical Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartAMC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartAMC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTAMC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTAMC/oauth2/authorize",
     "managingOrganization": "OCHIN"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "4e46681c-9317-48bd-91a6-628600d00ba5",
+    "name": "Allina",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://epicproxy.et1138.epichosted.com/FHIRProxy/api/FHIR/R4/",
@@ -224,11 +240,11 @@
     "managingOrganization": "AltaMed"
   },
   {
-    "url": "https://epicsoap.altru.org/fhir/STANDARD/api/FHIR/R4/",
+    "url": "https://epicproxy.et0714.epichosted.com/APIProxyPRD/STANDARD/api/FHIR/R4/",
     "id": "f590c9a5-671d-4103-9156-33970b6b4648",
     "name": "Altru",
-    "token": "https://epicsoap.altru.org/fhir/STANDARD/oauth2/token",
-    "authorize": "https://epicsoap.altru.org/fhir/STANDARD/oauth2/authorize",
+    "token": "https://epicproxy.et0714.epichosted.com/APIProxyPRD/STANDARD/oauth2/token",
+    "authorize": "https://epicproxy.et0714.epichosted.com/APIProxyPRD/STANDARD/oauth2/authorize",
     "managingOrganization": "Altru Health System"
   },
   {
@@ -240,11 +256,19 @@
     "managingOrganization": "AnMed"
   },
   {
-    "url": "https://epicmobile.centracare.com/fhir/api/FHIR/R4/",
-    "id": "3f5fcbb6-18bc-4cf0-b590-983cd515e406",
+    "url": "https://epicmobile.luriechildrens.org/Interconnect-FHIRPRD/HOME/api/FHIR/R4/",
+    "id": "1587fc7d-cbdf-4484-b958-91d525c44ec4",
+    "name": "Ann & Robert H. Lurie Children's Hospital of Chicago",
+    "token": "https://epicmobile.luriechildrens.org/Interconnect-FHIRPRD/HOME/oauth2/token",
+    "authorize": "https://epicmobile.luriechildrens.org/Interconnect-FHIRPRD/HOME/oauth2/authorize",
+    "managingOrganization": "Ann & Robert H. Lurie Children's Hospital of Chicago"
+  },
+  {
+    "url": "https://epicproxy.et0515.epichosted.com/APIProxyPRD/api/FHIR/R4/",
+    "id": "fe0fe754-2fc3-406c-8531-27af2d3740c4",
     "name": "Appleton Health",
-    "token": "https://epicmobile.centracare.com/fhir/oauth2/token",
-    "authorize": "https://epicmobile.centracare.com/fhir/oauth2/authorize",
+    "token": "https://epicproxy.et0515.epichosted.com/APIProxyPRD/oauth2/token",
+    "authorize": "https://epicproxy.et0515.epichosted.com/APIProxyPRD/oauth2/authorize",
     "managingOrganization": "CentraCare Health System"
   },
   {
@@ -328,19 +352,19 @@
     "managingOrganization": "Ascension"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartACRS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTACRS/api/FHIR/R4/",
     "id": "8286cda0-bd5c-48cd-b87a-3a34ef15470c",
     "name": "Asian Counseling and Referral Service",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartACRS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartACRS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTACRS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTACRS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartahs/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTAHS/api/FHIR/R4/",
     "id": "53e8d34a-25bf-4c6c-97ad-e4aad63f8415",
     "name": "Asian Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartahs/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartahs/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTAHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTAHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -377,7 +401,7 @@
   },
   {
     "url": "https://iatrius.atriushealth.org/FHIR/api/FHIR/R4/",
-    "id": "10583748-dd07-4a54-a51d-2ec08b867461",
+    "id": "5f3613ed-26a9-4d06-b078-047192a06af3",
     "name": "Atrius Health",
     "token": "https://iatrius.atriushealth.org/FHIR/oauth2/token",
     "authorize": "https://iatrius.atriushealth.org/FHIR/oauth2/authorize",
@@ -408,11 +432,11 @@
     "managingOrganization": "FastMed"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartA360/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTA360/api/FHIR/R4/",
     "id": "ae10b8d8-1dd7-4c57-94d1-3a7293565367",
     "name": "Avenue 360",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartA360/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartA360/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTA360/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTA360/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -424,11 +448,11 @@
     "managingOrganization": "The Ohio State University Wexner Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartaxis/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTAXIS/api/FHIR/R4/",
     "id": "d4c4c0c8-110a-41fb-b608-57822db2e0ee",
     "name": "Axis Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartaxis/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartaxis/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTAXIS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTAXIS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -441,11 +465,27 @@
   },
   {
     "url": "https://soap.wellmont.org/FHIRPRD/api/FHIR/R4/",
-    "id": "3ab84b6b-1141-42d4-bf0a-ddf43588b54d",
+    "id": "7f098e9a-50bc-415b-9542-38e9ba9b29e1",
     "name": "Ballad Health",
     "token": "https://soap.wellmont.org/FHIRPRD/oauth2/token",
     "authorize": "https://soap.wellmont.org/FHIRPRD/oauth2/authorize",
     "managingOrganization": "Ballad Health"
+  },
+  {
+    "url": "https://api.baptist-health.org/Interconnect-FHIR/api/FHIR/R4/",
+    "id": "d44bcf2a-93ab-453c-9184-24b153641b5a",
+    "name": "Baptist Health",
+    "token": "https://api.baptist-health.org/Interconnect-FHIR/oauth2/token",
+    "authorize": "https://api.baptist-health.org/Interconnect-FHIR/oauth2/authorize",
+    "managingOrganization": "Baptist Health (AR)"
+  },
+  {
+    "url": "https://epicproxy.et1131.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "7ba697da-ed93-4c17-8d3a-dce06c85024a",
+    "name": "Baptist Health",
+    "token": "https://epicproxy.et1131.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1131.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "Orlando Health"
   },
   {
     "url": "https://epicproxy.et1206.epichosted.com/FHIRProxy/BHJ/api/FHIR/R4/",
@@ -488,11 +528,11 @@
     "managingOrganization": "Renown Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartBACHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTBACHC/api/FHIR/R4/",
     "id": "c065ff05-7591-4aa8-bde4-5bc0b4f4a943",
     "name": "Bartz-Altadonna Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartBACHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartBACHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTBACHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTBACHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -517,14 +557,14 @@
     "name": "Baton Rouge Orthopaedic Clinic",
     "token": "https://epicproxy.et0830.epichosted.com/FHIRProxy/oauth2/token",
     "authorize": "https://epicproxy.et0830.epichosted.com/FHIRProxy/oauth2/authorize",
-    "managingOrganization": "Franciscan Missionaries of Our Lady Health"
+    "managingOrganization": "FMOL Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartBACH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTBACH/api/FHIR/R4/",
     "id": "8bf94058-5573-465d-9913-e07025a4dd42",
     "name": "Bay Area Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartBACH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartBACH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTBACH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTBACH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -544,6 +584,14 @@
     "managingOrganization": "St. Charles Health System"
   },
   {
+    "url": "https://epproxy.bayhealth.org/FHIR/HOME/api/FHIR/R4/",
+    "id": "d627e127-f73c-428e-ad5f-b4140ac7b496",
+    "name": "Bayhealth Medical Center",
+    "token": "https://epproxy.bayhealth.org/FHIR/HOME/oauth2/token",
+    "authorize": "https://epproxy.bayhealth.org/FHIR/HOME/oauth2/authorize",
+    "managingOrganization": "Bayhealth Medical Center"
+  },
+  {
     "url": "https://fhir.clinical.bcm.edu/Stage1Fhir/BCMMYC/api/FHIR/R4/",
     "id": "932e8917-d6e7-48e4-9758-b01a4dc46136",
     "name": "Baylor",
@@ -560,27 +608,27 @@
     "managingOrganization": "Baylor Scott & White Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartbaywell/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTBAYWELL/api/FHIR/R4/",
     "id": "b3e2f051-64f5-4c34-b13c-900f87d668bf",
     "name": "Baywell Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartbaywell/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartbaywell/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTBAYWELL/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTBAYWELL/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/BLMHospital/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/BLMHOSPITAL/api/FHIR/R4/",
     "id": "1c00507f-027a-40aa-9841-1c15dc310649",
     "name": "Bear Lake Memorial Clinic",
-    "token": "https://webprd.ochin.org/prd-fhir/BLMHospital/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/BLMHospital/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/BLMHOSPITAL/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/BLMHOSPITAL/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartbbwc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTBBWC/api/FHIR/R4/",
     "id": "df4c4e09-1e95-4b6f-a55d-a7df29c7b57a",
     "name": "Bee Busy Wellness Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartbbwc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartbbwc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTBBWC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTBBWC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -632,11 +680,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/bestcaretreatment/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/BESTCARETREATMENT/api/FHIR/R4/",
     "id": "d1f8f5bb-9d5a-4d07-bb0a-6f15c57b01bc",
     "name": "BestCare Treatment",
-    "token": "https://webprd.ochin.org/prd-fhir/bestcaretreatment/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/bestcaretreatment/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/BESTCARETREATMENT/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/BESTCARETREATMENT/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -656,12 +704,28 @@
     "managingOrganization": "Lehigh Valley Hospital"
   },
   {
+    "url": "https://webprd.ochin.org/prd-fhir/api/FHIR/R4/",
+    "id": "018e70d4-ad59-474c-af04-20f1f3574f94",
+    "name": "Bigfork Valley",
+    "token": "https://webprd.ochin.org/prd-fhir/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/oauth2/authorize",
+    "managingOrganization": "OCHIN"
+  },
+  {
     "url": "https://epicproxy.et0645.epichosted.com/FHIRProxyPRD/api/FHIR/R4/",
     "id": "ada4f01f-bebe-453b-a8ca-ffc16a7367d7",
     "name": "Billings OBGYN",
     "token": "https://epicproxy.et0645.epichosted.com/FHIRProxyPRD/oauth2/token",
     "authorize": "https://epicproxy.et0645.epichosted.com/FHIRProxyPRD/oauth2/authorize",
     "managingOrganization": "Intermountain Health"
+  },
+  {
+    "url": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/api/FHIR/R4/",
+    "id": "55d3c938-0149-4022-aecf-cd75b4f45821",
+    "name": "BioSpine Institute",
+    "token": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/token",
+    "authorize": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/authorize",
+    "managingOrganization": "NCH Healthcare System"
   },
   {
     "url": "https://epicproxy.et0965.epichosted.com/FHIRProxy/api/FHIR/R4/",
@@ -733,7 +797,7 @@
     "name": "Brockton Neighborhood Health Center",
     "token": "https://epicproxy.et1290.epichosted.com/FHIRProxy/oauth2/token",
     "authorize": "https://epicproxy.et1290.epichosted.com/FHIRProxy/oauth2/authorize",
-    "managingOrganization": "Community Technology Cooperative"
+    "managingOrganization": "Community Care Cooperative"
   },
   {
     "url": "https://epicproxy.et1043.epichosted.com/FHIRProxy/api/FHIR/R4/",
@@ -792,11 +856,11 @@
     "managingOrganization": "Buffalo Medical Group"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/burnettmedicalcenter/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/BURNETTMEDICALCENTER/api/FHIR/R4/",
     "id": "57ced600-c6e7-4251-ae04-855b982b4e96",
     "name": "Burnett Medical Center",
-    "token": "https://webprd.ochin.org/prd-fhir/burnettmedicalcenter/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/burnettmedicalcenter/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/BURNETTMEDICALCENTER/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/BURNETTMEDICALCENTER/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -805,7 +869,7 @@
     "name": "Burnsville Family Physicians",
     "token": "https://sfd.fairview.org/FHIR/BFP/oauth2/token",
     "authorize": "https://sfd.fairview.org/FHIR/BFP/oauth2/authorize",
-    "managingOrganization": "M Health Fairview"
+    "managingOrganization": "Fairview"
   },
   {
     "url": "https://epicproxy.et4001.epichosted.com/APIProxyPRD/CFM/api/FHIR/R4/",
@@ -816,11 +880,19 @@
     "managingOrganization": "Garden Plot"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/camcare/api/FHIR/R4/",
+    "url": "https://epicmobile.challiance.org/Interconnect-OAuth2/api/FHIR/R4/",
+    "id": "df45de37-128e-4e69-937d-b14a95c32fb5",
+    "name": "Cambridge Health Alliance",
+    "token": "https://epicmobile.challiance.org/Interconnect-OAuth2/oauth2/token",
+    "authorize": "https://epicmobile.challiance.org/Interconnect-OAuth2/oauth2/authorize",
+    "managingOrganization": "Cambridge Health Alliance"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/CAMCARE/api/FHIR/R4/",
     "id": "bf0c7a08-4aa0-44e6-bbf4-b14e9badb8fe",
     "name": "CamCare",
-    "token": "https://webprd.ochin.org/prd-fhir/camcare/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/camcare/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CAMCARE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CAMCARE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -832,19 +904,35 @@
     "managingOrganization": "OSF HealthCare"
   },
   {
-    "url": "https://epicproxy.et1149.epichosted.com/FHIRProxy/HOME/api/FHIR/R4/",
-    "id": "a6bd4fe9-f88d-47fd-b9fe-06f664b73d99",
+    "url": "https://epicproxy.et1149.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "9a90b319-e163-4328-bc69-060219faea7c",
     "name": "Cape Cod Healthcare",
-    "token": "https://epicproxy.et1149.epichosted.com/FHIRProxy/HOME/oauth2/token",
-    "authorize": "https://epicproxy.et1149.epichosted.com/FHIRProxy/HOME/oauth2/authorize",
+    "token": "https://epicproxy.et1149.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1149.epichosted.com/FHIRProxy/oauth2/authorize",
     "managingOrganization": "Cape Cod HealthCare"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCA/api/FHIR/R4/",
+    "url": "https://epicproxy.et1094.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "791547cf-029c-4fe3-8ee3-51de0f10dc60",
+    "name": "Cape Fear Valley",
+    "token": "https://epicproxy.et1094.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1094.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "Cape Fear Valley Health"
+  },
+  {
+    "url": "https://epicproxy.et1222.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "2fd915c5-5e2b-ec11-9152-001dd8b71f19",
+    "name": "Capital Medical Group",
+    "token": "https://epicproxy.et1222.epichosted.com/FHIRPROXY/oauth2/token",
+    "authorize": "https://epicproxy.et1222.epichosted.com/FHIRPROXY/oauth2/authorize",
+    "managingOrganization": "GW University Medical Faculty Associates"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCA/api/FHIR/R4/",
     "id": "c42b1dce-80e5-4631-acf7-5aa5ffdc4bed",
     "name": "Care Alliance Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCA/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCA/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -856,11 +944,11 @@
     "managingOrganization": "Care New England"
   },
   {
-    "url": "https://interconnect.carelonhealth.com/Interconnect-PRD-OAuth2/api/FHIR/R4/",
-    "id": "eaae90be-f0a5-ef11-91e5-0050568bc890",
+    "url": "https://interconnect.carelon.com/Interconnect-PRD-OAuth2/api/FHIR/R4/",
+    "id": "93271764-36d8-436e-9c58-c40637d46190",
     "name": "Carelon",
-    "token": "https://interconnect.carelonhealth.com/Interconnect-PRD-OAuth2/oauth2/token",
-    "authorize": "https://interconnect.carelonhealth.com/Interconnect-PRD-OAuth2/oauth2/authorize",
+    "token": "https://interconnect.carelon.com/Interconnect-PRD-OAuth2/oauth2/token",
+    "authorize": "https://interconnect.carelon.com/Interconnect-PRD-OAuth2/oauth2/authorize",
     "managingOrganization": "Carelon"
   },
   {
@@ -888,19 +976,19 @@
     "managingOrganization": "MultiCare Health System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartcfhc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCFHC/api/FHIR/R4/",
     "id": "52bb4e74-dfe6-47bb-83e3-769890df3ae1",
     "name": "Carolina Family Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartcfhc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartcfhc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCFHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCFHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCHC/api/FHIR/R4/",
     "id": "2d9e36fc-8ff7-4997-ae16-3ff1503f1f05",
     "name": "Carolina Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -944,19 +1032,19 @@
     "managingOrganization": "Garden Plot"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/cascademedicalcenter/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CASCADEMEDICALCENTER/api/FHIR/R4/",
     "id": "f8ed9218-e1fe-4fe7-98dd-3a14f533bcd5",
     "name": "Cascade Medical Center",
-    "token": "https://webprd.ochin.org/prd-fhir/cascademedicalcenter/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/cascademedicalcenter/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CASCADEMEDICALCENTER/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CASCADEMEDICALCENTER/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/CascadiaHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CASCADIAHEALTH/api/FHIR/R4/",
     "id": "6bf1fe30-a110-4f3b-b251-6e662e468955",
     "name": "Cascadia Health",
-    "token": "https://webprd.ochin.org/prd-fhir/CascadiaHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/CascadiaHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CASCADIAHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CASCADIAHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -992,19 +1080,19 @@
     "managingOrganization": "CEENTA"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCempa/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCEMPA/api/FHIR/R4/",
     "id": "ad80114b-7b51-4847-939f-2b482220f2fd",
     "name": "Cempa Community Care",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCempa/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCempa/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCEMPA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCEMPA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/centralcityconcern/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CENTRALCITYCONCERN/api/FHIR/R4/",
     "id": "05fd31c3-cbe7-4a71-912c-c76fdf4554d3",
     "name": "Central City Concern",
-    "token": "https://webprd.ochin.org/prd-fhir/centralcityconcern/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/centralcityconcern/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CENTRALCITYCONCERN/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CENTRALCITYCONCERN/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1024,11 +1112,11 @@
     "managingOrganization": "Central Ohio Primary Care Physicians"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/centraloutreach/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CENTRALOUTREACH/api/FHIR/R4/",
     "id": "c6a7e9de-01f4-4817-8c72-ca7ff8aba34f",
     "name": "Central Outreach Wellness Center",
-    "token": "https://webprd.ochin.org/prd-fhir/centraloutreach/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/centraloutreach/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CENTRALOUTREACH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CENTRALOUTREACH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1056,11 +1144,11 @@
     "managingOrganization": "CGH Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartchap/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCHAP/api/FHIR/R4/",
     "id": "f28ade56-24e7-44ac-9eee-c2c61be7ecf8",
     "name": "ChapCare",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartchap/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartchap/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCHAP/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCHAP/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1144,11 +1232,11 @@
     "managingOrganization": "Children's Health"
   },
   {
-    "url": "https://wpprod.choa.org/FHIR_PRD/api/FHIR/R4/",
+    "url": "https://wpprod.choa.org/FHIR_PRD/PRD/api/FHIR/R4/",
     "id": "a7e197c1-d6ae-48e8-a1a3-26d54a892564",
     "name": "Children's Healthcare of Atlanta",
-    "token": "https://wpprod.choa.org/FHIR_PRD/oauth2/token",
-    "authorize": "https://wpprod.choa.org/FHIR_PRD/oauth2/authorize",
+    "token": "https://wpprod.choa.org/FHIR_PRD/PRD/oauth2/token",
+    "authorize": "https://wpprod.choa.org/FHIR_PRD/PRD/oauth2/authorize",
     "managingOrganization": "Children's Healthcare of Atlanta"
   },
   {
@@ -1161,7 +1249,7 @@
   },
   {
     "url": "https://fhir.childrenscolorado.org/fhirprd/api/FHIR/R4/",
-    "id": "d136e221-a5f8-4fe0-9898-dd590c65acf2",
+    "id": "c6b565c7-0c38-ec11-9155-001dd8b71f19",
     "name": "Children's Hospital Colorado",
     "token": "https://fhir.childrenscolorado.org/fhirprd/oauth2/token",
     "authorize": "https://fhir.childrenscolorado.org/fhirprd/oauth2/authorize",
@@ -1240,11 +1328,11 @@
     "managingOrganization": "Citizen Potawatomi Nation Health Services"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/cmciks/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CMCIKS/api/FHIR/R4/",
     "id": "19f3d4de-a3cb-435d-b6eb-ba4006ef4e12",
     "name": "Citizens Health",
-    "token": "https://webprd.ochin.org/prd-fhir/cmciks/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/cmciks/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CMCIKS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CMCIKS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1264,11 +1352,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartClackamas/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCLACKAMAS/api/FHIR/R4/",
     "id": "31daf288-8f3c-4515-8167-601fb55a4a37",
     "name": "Clackamas County Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartClackamas/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartClackamas/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCLACKAMAS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCLACKAMAS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1280,19 +1368,19 @@
     "managingOrganization": "Cleveland Clinic"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCR/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCR/api/FHIR/R4/",
     "id": "248d4559-451d-41e9-98bb-c993cc2c5e5a",
     "name": "Clinica Romero",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCR/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCR/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCR/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCR/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://epicproxy.et1430.epichosted.com/APIPROXYPRD/api/FHIR/R4/",
+    "url": "https://epicproxy.et1430.epichosted.com/APIPROXYPRD/CSV/api/FHIR/R4/",
     "id": "9a5bd48a-f2bf-4766-8dd4-5bd6c2e15d67",
     "name": "Clinica Sierra Vista",
-    "token": "https://epicproxy.et1430.epichosted.com/APIPROXYPRD/oauth2/token",
-    "authorize": "https://epicproxy.et1430.epichosted.com/APIPROXYPRD/oauth2/authorize",
+    "token": "https://epicproxy.et1430.epichosted.com/APIPROXYPRD/CSV/oauth2/token",
+    "authorize": "https://epicproxy.et1430.epichosted.com/APIPROXYPRD/CSV/oauth2/authorize",
     "managingOrganization": "Clinica Sierra Vista"
   },
   {
@@ -1304,11 +1392,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCCHC/api/FHIR/R4/",
     "id": "9ca7d01a-895d-44da-b6ba-7ee25b6e41e1",
     "name": "Coast Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1336,11 +1424,11 @@
     "managingOrganization": "Providence St. Joseph Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCRH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCRH/api/FHIR/R4/",
     "id": "193292a2-dfdb-4ea1-98dd-ee9824eb61c7",
     "name": "Columbia River Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCRH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCRH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCRH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCRH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1376,35 +1464,35 @@
     "managingOrganization": "CommonSpirit Mountain Region"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/ccolemychart/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CCOLEMYCHART/api/FHIR/R4/",
     "id": "1000062b-f9d1-4af0-a004-62340622e559",
     "name": "CommuniCare+OLE",
-    "token": "https://webprd.ochin.org/prd-fhir/ccolemychart/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/ccolemychart/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CCOLEMYCHART/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CCOLEMYCHART/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/chcqca/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CHCQCA/api/FHIR/R4/",
     "id": "e8dc30fb-19bc-4977-86c2-9102f4e22bfe",
     "name": "Community Health Care, Inc",
-    "token": "https://webprd.ochin.org/prd-fhir/chcqca/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/chcqca/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CHCQCA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CHCQCA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/chcfd/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CHCFD/api/FHIR/R4/",
     "id": "c8b06b6a-7f04-496b-8ddf-d19b881d261c",
     "name": "Community Health Center of Fort Dodge",
-    "token": "https://webprd.ochin.org/prd-fhir/chcfd/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/chcfd/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CHCFD/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CHCFD/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/chcseia/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CHCSEIA/api/FHIR/R4/",
     "id": "e2cdcf06-a6ae-4342-829b-ae9f1154db34",
     "name": "Community Health Center of Southeastern Iowa",
-    "token": "https://webprd.ochin.org/prd-fhir/chcseia/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/chcseia/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CHCSEIA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CHCSEIA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1424,27 +1512,27 @@
     "managingOrganization": "Community Health Network"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCHCW/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCHCW/api/FHIR/R4/",
     "id": "6ff4c26f-8c0b-4afb-8ccb-765f38501591",
     "name": "Community Health of Central Washington",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCHCW/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCHCW/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCHCW/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCHCW/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/CHSImychart/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CHSIMYCHART/api/FHIR/R4/",
     "id": "dea71309-a368-4d27-9c09-7fd9051ca0a3",
     "name": "Community Health Services, Inc",
-    "token": "https://webprd.ochin.org/prd-fhir/CHSImychart/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/CHSImychart/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CHSIMYCHART/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CHSIMYCHART/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCHSOFWI/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCHSOFWI/api/FHIR/R4/",
     "id": "62f3743a-96e0-4cff-81ef-e4e0707881bf",
     "name": "Community Health Systems",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCHSOFWI/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCHSOFWI/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCHSOFWI/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCHSOFWI/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1544,19 +1632,27 @@
     "managingOrganization": "Conemaugh Health System"
   },
   {
+    "url": "https://epicproxy.et0764.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "4c58664b-6540-43a4-8e87-b2adeea63579",
+    "name": "Confluence Health",
+    "token": "https://epicproxy.et0764.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et0764.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "Confluence Health"
+  },
+  {
     "url": "https://epicproxy.connecticutchildrens.org/FHIR/api/FHIR/R4/",
-    "id": "77e3f390-01bc-4ca3-a710-04c3c6b2064a",
-    "name": "Connecticut Children's Medical Center",
+    "id": "3793a493-bd7f-4f19-9c25-679afbef844f",
+    "name": "Connecticut Children's",
     "token": "https://epicproxy.connecticutchildrens.org/FHIR/oauth2/token",
     "authorize": "https://epicproxy.connecticutchildrens.org/FHIR/oauth2/authorize",
     "managingOrganization": "Connecticut Children's"
   },
   {
-    "url": "https://icproxy.mycclink.org/proxy-FHIR/api/FHIR/R4/",
+    "url": "https://epicproxy.et0421.epichosted.com/APIPROXYPRD/api/FHIR/R4/",
     "id": "9280550a-db56-42d3-8272-48e8dc272702",
     "name": "Contra Costa Health Services",
-    "token": "https://icproxy.mycclink.org/proxy-FHIR/oauth2/token",
-    "authorize": "https://icproxy.mycclink.org/proxy-FHIR/oauth2/authorize",
+    "token": "https://epicproxy.et0421.epichosted.com/APIPROXYPRD/oauth2/token",
+    "authorize": "https://epicproxy.et0421.epichosted.com/APIPROXYPRD/oauth2/authorize",
     "managingOrganization": "Contra Costa Health"
   },
   {
@@ -1578,7 +1674,7 @@
   {
     "url": "https://epicarr02.spectrumhealth.org/EpicFHIR/HOME/api/FHIR/R4/",
     "id": "689f48a0-4957-433d-92e8-9f2282f59956",
-    "name": "Corewell Health West",
+    "name": "Corewell Health",
     "token": "https://epicarr02.spectrumhealth.org/EpicFHIR/HOME/oauth2/token",
     "authorize": "https://epicarr02.spectrumhealth.org/EpicFHIR/HOME/oauth2/authorize",
     "managingOrganization": "Corewell Health"
@@ -1624,11 +1720,11 @@
     "managingOrganization": "CoxHealth"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/crescentchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/CRESCENTCHC/api/FHIR/R4/",
     "id": "dfa04d2c-0cbf-43f3-bcd5-c8b9da7ef2a5",
     "name": "Crescent Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/crescentchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/crescentchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/CRESCENTCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/CRESCENTCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1640,11 +1736,19 @@
     "managingOrganization": "Emplify Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartdap/api/FHIR/R4/",
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "deceab52-2c3e-4726-b0e2-f9361f507d29",
+    "name": "Cuyuna Regional Medical Center",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTDAP/api/FHIR/R4/",
     "id": "bb35db7d-9efa-4e5b-a6cd-d6af29a3f2c9",
     "name": "DAP",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartdap/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartdap/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTDAP/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTDAP/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1688,6 +1792,14 @@
     "managingOrganization": "Denver Health"
   },
   {
+    "url": "https://epicproxy.et1031.epichosted.com/FHIRProxy/DCL/api/FHIR/R4/",
+    "id": "cb8edbf0-3957-4601-905d-26e4b603b7bb",
+    "name": "Dialysis Center of Lincoln",
+    "token": "https://epicproxy.et1031.epichosted.com/FHIRProxy/DCL/oauth2/token",
+    "authorize": "https://epicproxy.et1031.epichosted.com/FHIRProxy/DCL/oauth2/authorize",
+    "managingOrganization": "Bryan Health"
+  },
+  {
     "url": "https://epicproxy.et4001.epichosted.com/APIProxyPRD/DMA/api/FHIR/R4/",
     "id": "c01b54cd-6761-42c2-bcc8-ce5270f233e3",
     "name": "Dickson Medical Associates",
@@ -1702,6 +1814,14 @@
     "token": "https://epicproxy.et1326.epichosted.com/FHIRProxy/MHCC/oauth2/token",
     "authorize": "https://epicproxy.et1326.epichosted.com/FHIRProxy/MHCC/oauth2/authorize",
     "managingOrganization": "Memorial Hermann"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "623c8a09-d21d-46c3-ac9c-d8793000a66a",
+    "name": "District One Hospital",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://epicproxy.et1146.epichosted.com/FHIRProxy/api/FHIR/R4/",
@@ -1744,11 +1864,11 @@
     "managingOrganization": "Duly Health and Care"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartEagleViewHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTEAGLEVIEWHEALTH/api/FHIR/R4/",
     "id": "8e79ec9c-7f5c-4674-bd0d-626171ffd5ef",
     "name": "Eagle View Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartEagleViewHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartEagleViewHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTEAGLEVIEWHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTEAGLEVIEWHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1808,11 +1928,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartehc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTEHC/api/FHIR/R4/",
     "id": "5b2fdc20-c123-40bf-baa0-4eb05688f3f8",
     "name": "Elica Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartehc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartehc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTEHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTEHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1848,6 +1968,14 @@
     "managingOrganization": "Endeavor Health - NorthShore University HealthSystem"
   },
   {
+    "url": "https://epicproxy.et1073.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "02d17341-8ad5-4726-89be-5cbe66f34708",
+    "name": "Englewood",
+    "token": "https://epicproxy.et1073.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1073.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "Englewood Hospital and Medical Center"
+  },
+  {
     "url": "https://epicproxy.et1034.epichosted.com/FHIRProxy/STANDARD/api/FHIR/R4/",
     "id": "569b52ab-f937-4a91-8506-ae6ef29037f5",
     "name": "Enloe Medical Center",
@@ -1856,11 +1984,11 @@
     "managingOrganization": "Enloe Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartequitas/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTEQUITAS/api/FHIR/R4/",
     "id": "97cd2062-8af1-4f82-ace3-7ba1e9a165a5",
     "name": "Equitas Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartequitas/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartequitas/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTEQUITAS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTEQUITAS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1886,6 +2014,14 @@
     "token": "https://m.essentiahealth.org/FHIR/oauth2/token",
     "authorize": "https://m.essentiahealth.org/FHIR/oauth2/authorize",
     "managingOrganization": "Essentia Health"
+  },
+  {
+    "url": "https://soap.wellmont.org/FHIRPRD/COMMUNITY/api/FHIR/R4/",
+    "id": "7b49f4f9-bdd5-46aa-aaac-157b3bc87e38",
+    "name": "ETSU Health",
+    "token": "https://soap.wellmont.org/FHIRPRD/COMMUNITY/oauth2/token",
+    "authorize": "https://soap.wellmont.org/FHIRPRD/COMMUNITY/oauth2/authorize",
+    "managingOrganization": "Ballad Health"
   },
   {
     "url": "https://geisapi.geisinger.edu/FHIR_PROD/api/FHIR/R4/",
@@ -1944,19 +2080,19 @@
     "managingOrganization": "Family Care Network"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/familyhealthcenter/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/FAMILYHEALTHCENTER/api/FHIR/R4/",
     "id": "613a27c0-31d2-44dc-bee6-e1de21a09567",
     "name": "Family Health Center of Marshfield",
-    "token": "https://webprd.ochin.org/prd-fhir/familyhealthcenter/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/familyhealthcenter/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/FAMILYHEALTHCENTER/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/FAMILYHEALTHCENTER/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/myerie/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYERIE/api/FHIR/R4/",
     "id": "e33fd1e8-c483-49a7-bacf-0892e4d8b201",
     "name": "Family Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/myerie/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/myerie/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYERIE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYERIE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -1968,11 +2104,11 @@
     "managingOrganization": "FastMed"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSVDP/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSVDP/api/FHIR/R4/",
     "id": "19c8aba9-8737-41d6-8720-f7f1f7ea6da5",
     "name": "Father Joe's Villages",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSVDP/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSVDP/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSVDP/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSVDP/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2024,19 +2160,19 @@
     "managingOrganization": "Boston Children's Hospital"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartFPHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTFPHC/api/FHIR/R4/",
     "id": "b8cd31de-ae94-4ad8-8861-666b953e55a3",
     "name": "Franklin Primary Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartFPHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartFPHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTFPHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTFPHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/FOFHealthCenter/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/FOFHEALTHCENTER/api/FHIR/R4/",
     "id": "a9ac4dd4-4139-44dc-a1e8-e9e9a5c15ede",
     "name": "Friends of Family Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/FOFHealthCenter/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/FOFHealthCenter/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/FOFHEALTHCENTER/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/FOFHEALTHCENTER/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2048,11 +2184,11 @@
     "managingOrganization": "Froedtert & The Medical College of Wisconsin"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartFCH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTFCH/api/FHIR/R4/",
     "id": "e4d62830-eae8-41b3-875d-b820b1a896b8",
     "name": "Full Circle Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartFCH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartFCH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTFCH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTFCH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2064,11 +2200,11 @@
     "managingOrganization": "The University of Mississippi Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartGHS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTGHS/api/FHIR/R4/",
     "id": "0c3f5ffb-e38e-43dc-b572-5862208de382",
     "name": "Gardner Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartGHS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartGHS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTGHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTGHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2104,12 +2240,28 @@
     "managingOrganization": "Memorial Hermann"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartgliihc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTGLIIHC/api/FHIR/R4/",
     "id": "9bfb6119-e3ec-45a4-afb9-6bd4599cb3c2",
     "name": "Gerald L. Ignace Indian Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartgliihc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartgliihc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTGLIIHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTGLIIHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
+  },
+  {
+    "url": "https://linkpoint.ghcscw.com/Interconnect-PRD-FHIR/api/FHIR/R4/",
+    "id": "205e8418-9e29-45c4-9e1b-4bd2ec3d7479",
+    "name": "GHC",
+    "token": "https://linkpoint.ghcscw.com/Interconnect-PRD-FHIR/oauth2/token",
+    "authorize": "https://linkpoint.ghcscw.com/Interconnect-PRD-FHIR/oauth2/authorize",
+    "managingOrganization": "Group Health Cooperative - South Central Wisconsin"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "5d477544-263e-4069-9f80-58f1b8906d05",
+    "name": "Glencoe Regional Health Services",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://epicproxy.et1332.epichosted.com/FHIRProxy/api/FHIR/R4/",
@@ -2136,27 +2288,27 @@
     "managingOrganization": "Golden Valley Health Centers"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartgsm/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTGSM/api/FHIR/R4/",
     "id": "78f75317-3eeb-48a3-9a99-1f189e0d1556",
     "name": "GoldenShore Medical",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartgsm/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartgsm/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTGSM/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTGSM/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/gracehealthKY/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/GRACEHEALTHKY/api/FHIR/R4/",
     "id": "608644f4-94a6-4857-b141-e75c2b6b151b",
     "name": "Grace Health",
-    "token": "https://webprd.ochin.org/prd-fhir/gracehealthKY/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/gracehealthKY/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/GRACEHEALTHKY/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/GRACEHEALTHKY/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartGCH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTGCH/api/FHIR/R4/",
     "id": "4c1d38e9-f37c-4b23-a4f8-0a6dbfbd66f8",
     "name": "Gracelight Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartGCH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartGCH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTGCH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTGCH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2168,6 +2320,14 @@
     "managingOrganization": "Grady Health System"
   },
   {
+    "url": "https://epicproxy.et1475.epichosted.com/APIPROXYPRD/api/FHIR/R4/",
+    "id": "2f9b7106-dab9-4d56-a6fd-0713196a0303",
+    "name": "Great River Health",
+    "token": "https://epicproxy.et1475.epichosted.com/APIPROXYPRD/oauth2/token",
+    "authorize": "https://epicproxy.et1475.epichosted.com/APIPROXYPRD/oauth2/authorize",
+    "managingOrganization": "Great River Health"
+  },
+  {
     "url": "https://eportal.gbmc.org/fhir/api/FHIR/R4/",
     "id": "0f076b24-b156-4bbd-b4cc-8f7406230dc0",
     "name": "Greater Baltimore Medical Center",
@@ -2176,11 +2336,11 @@
     "managingOrganization": "Greater Baltimore Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/gritman/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/GRITMAN/api/FHIR/R4/",
     "id": "46cd9a42-8250-4b19-9340-fa4368c47b3b",
     "name": "Gritman Medical Center",
-    "token": "https://webprd.ochin.org/prd-fhir/gritman/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/gritman/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/GRITMAN/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/GRITMAN/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2190,14 +2350,6 @@
     "token": "https://fhir.guthrie.org/FHIR-PRD/oauth2/token",
     "authorize": "https://fhir.guthrie.org/FHIR-PRD/oauth2/authorize",
     "managingOrganization": "The Guthrie Clinic"
-  },
-  {
-    "url": "https://epicproxy.et1222.epichosted.com/FHIRProxy/api/FHIR/R4/",
-    "id": "2fd915c5-5e2b-ec11-9152-001dd8b71f19",
-    "name": "GW University Medical Faculty Associates",
-    "token": "https://epicproxy.et1222.epichosted.com/FHIRPROXY/oauth2/token",
-    "authorize": "https://epicproxy.et1222.epichosted.com/FHIRPROXY/oauth2/authorize",
-    "managingOrganization": "GW University Medical Faculty Associates"
   },
   {
     "url": "https://webprd.ochin.org/prd-fhir/HABITATHEALTH/api/FHIR/R4/",
@@ -2224,11 +2376,11 @@
     "managingOrganization": "Halifax Hospital Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mycharthh/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTHH/api/FHIR/R4/",
     "id": "e1de9003-bcda-4c0d-ad6a-0f52b34e2774",
     "name": "Harbor Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mycharthh/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mycharthh/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTHH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTHH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2240,11 +2392,11 @@
     "managingOrganization": "Delta Dental of California"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/myharmonyhealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYHARMONYHEALTH/api/FHIR/R4/",
     "id": "57582839-fd38-4aa3-b823-07b6443b11e1",
     "name": "Harmony Health Medical Clinic",
-    "token": "https://webprd.ochin.org/prd-fhir/myharmonyhealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/myharmonyhealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYHARMONYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYHARMONYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2272,19 +2424,19 @@
     "managingOrganization": "Hawaii Health Systems Corporation"
   },
   {
-    "url": "https://webservices.hawaiipacifichealth.org/fhir/api/FHIR/R4/",
+    "url": "https://epicproxy.et0471.epichosted.com/APIPROXYPRD/api/FHIR/R4/",
     "id": "ba59fc8a-3013-4424-8296-adc79c338c2b",
     "name": "Hawaii Pacific Health",
-    "token": "https://webservices.hawaiipacifichealth.org/fhir/oauth2/token",
-    "authorize": "https://webservices.hawaiipacifichealth.org/fhir/oauth2/authorize",
+    "token": "https://epicproxy.et0471.epichosted.com/APIPROXYPRD/oauth2/token",
+    "authorize": "https://epicproxy.et0471.epichosted.com/APIPROXYPRD/oauth2/authorize",
     "managingOrganization": "Hawaii Pacific Health"
   },
   {
-    "url": "https://epicsoapproxyprd.mountsinai.org/FHIR-PRD/api/FHIR/R4/",
+    "url": "https://epicproxy.et0513.epichosted.com/APIProxyPRD/api/FHIR/R4/",
     "id": "b78cd9c9-c9d5-47e8-b4a6-e18e0dfcc563",
     "name": "Health Center, powered by Mount Sinai",
-    "token": "https://epicsoapproxyprd.mountsinai.org/FHIR-PRD/oauth2/token",
-    "authorize": "https://epicsoapproxyprd.mountsinai.org/FHIR-PRD/oauth2/authorize",
+    "token": "https://epicproxy.et0513.epichosted.com/APIProxyPRD/oauth2/token",
+    "authorize": "https://epicproxy.et0513.epichosted.com/APIProxyPRD/oauth2/authorize",
     "managingOrganization": "Mount Sinai Health System"
   },
   {
@@ -2320,11 +2472,11 @@
     "managingOrganization": "HealthPoint"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartHealthRight360/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTHEALTHRIGHT360/api/FHIR/R4/",
     "id": "1457567c-ea24-4b52-a8e8-96d18044852b",
     "name": "HealthRIGHT 360",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartHealthRight360/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartHealthRight360/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTHEALTHRIGHT360/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTHEALTHRIGHT360/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2392,11 +2544,11 @@
     "managingOrganization": "Vanderbilt University Medical Center"
   },
   {
-    "url": "https://epicscripts.trihealth.com/fhirproxy/api/FHIR/R4/",
+    "url": "https://epicscripts.trihealth.com/fhirproxy/HOME/api/FHIR/R4/",
     "id": "308ebae3-71cf-42b6-9bd2-537cc32bc2d6",
     "name": "Highland District Hospital",
-    "token": "https://epicscripts.trihealth.com/fhirproxy/oauth2/token",
-    "authorize": "https://epicscripts.trihealth.com/fhirproxy/oauth2/authorize",
+    "token": "https://epicscripts.trihealth.com/fhirproxy/HOME/oauth2/token",
+    "authorize": "https://epicscripts.trihealth.com/fhirproxy/HOME/oauth2/authorize",
     "managingOrganization": "TriHealth"
   },
   {
@@ -2448,11 +2600,11 @@
     "managingOrganization": "Hospital for Special Surgery"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartHSH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTHSH/api/FHIR/R4/",
     "id": "6a37103d-f2f3-4dc0-ae2e-c9809ca361d5",
     "name": "Hot Springs Health Program",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartHSH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartHSH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTHSH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTHSH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2480,11 +2632,11 @@
     "managingOrganization": "Houston Methodist"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartHBH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTHBH/api/FHIR/R4/",
     "id": "bba6b783-a98b-4db1-9dd0-c41ac3fab1c1",
     "name": "Howard Brown Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartHBH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartHBH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTHBH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTHBH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2504,6 +2656,14 @@
     "managingOrganization": "Hurley Medical Center"
   },
   {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "05d3e8f7-4b82-4d7f-86b2-a805f6c61589",
+    "name": "Hutchinson Health",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
+  },
+  {
     "url": "https://epicproxy.et1195.epichosted.com/fhirproxy/api/FHIR/R4/",
     "id": "8bba83a9-4550-4b39-a8ba-f96839a66969",
     "name": "Illinois Bone & Joint Institute",
@@ -2512,11 +2672,11 @@
     "managingOrganization": "Illinois Bone & Joint Institute"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/Immanuel/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/IMMANUEL/api/FHIR/R4/",
     "id": "9cd61d09-fe09-4307-ab5d-c8f82083ded7",
     "name": "Immanuel PACE",
-    "token": "https://webprd.ochin.org/prd-fhir/Immanuel/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/Immanuel/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/IMMANUEL/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/IMMANUEL/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2528,27 +2688,35 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartIHCSCV/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTIHCSCV/api/FHIR/R4/",
     "id": "9d6f72b8-75b0-44c2-bedb-b52894fce412",
     "name": "Indian Health Center of Santa Clara Valley",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartIHCSCV/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartIHCSCV/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTIHCSCV/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTIHCSCV/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/indianhealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/INDIANHEALTH/api/FHIR/R4/",
     "id": "5da3c472-cc8c-43db-8263-4583bbbc7b09",
     "name": "Indian Health Council",
-    "token": "https://webprd.ochin.org/prd-fhir/indianhealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/indianhealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/INDIANHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/INDIANHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/weareinfinityhealth/api/FHIR/R4/",
+    "url": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/api/FHIR/R4/",
+    "id": "8c753f94-f6fb-4cd6-96f5-87431161c1d3",
+    "name": "Infectious Disease Associates of Naples",
+    "token": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/token",
+    "authorize": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/authorize",
+    "managingOrganization": "NCH Healthcare System"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/WEAREINFINITYHEALTH/api/FHIR/R4/",
     "id": "4f60905e-70f8-4f71-b7f6-e3d01416376e",
     "name": "Infinity Health Care",
-    "token": "https://webprd.ochin.org/prd-fhir/weareinfinityhealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/weareinfinityhealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/WEAREINFINITYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/WEAREINFINITYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2584,35 +2752,51 @@
     "managingOrganization": "Inova Health System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartintercommunity/api/FHIR/R4/",
+    "url": "https://epicproxy.et1473.epichosted.com/APIProxyPRD/api/FHIR/R4/",
+    "id": "a8f7845e-6339-48f6-9ed8-d4c13d1865e9",
+    "name": "InspiraHealth",
+    "token": "https://epicproxy.et1473.epichosted.com/APIProxyPRD/oauth2/token",
+    "authorize": "https://epicproxy.et1473.epichosted.com/APIProxyPRD/oauth2/authorize",
+    "managingOrganization": "Inspira Health"
+  },
+  {
+    "url": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/api/FHIR/R4/",
+    "id": "4a9cc77f-1635-449b-90c3-0b80f67b7ad1",
+    "name": "Integris Physician Group",
+    "token": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/token",
+    "authorize": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/authorize",
+    "managingOrganization": "NCH Healthcare System"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTINTERCOMMUNITY/api/FHIR/R4/",
     "id": "6e7274d7-807c-4ba9-a079-91bf72842888",
     "name": "InterCommunity Health Care",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartintercommunity/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartintercommunity/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTINTERCOMMUNITY/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTINTERCOMMUNITY/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/api/FHIR/R4/",
-    "id": "018e70d4-ad59-474c-af04-20f1f3574f94",
-    "name": "JAMHI",
-    "token": "https://webprd.ochin.org/prd-fhir/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/oauth2/authorize",
-    "managingOrganization": "OCHIN"
+    "url": "https://epicproxy.et1206.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "e9851f22-f0df-436f-a5e4-c2c352681edf",
+    "name": "Jacksonville Lung Clinic",
+    "token": "https://epicproxy.et1206.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1206.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "Baptist Health (Jacksonville"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartJPCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTJPCHC/api/FHIR/R4/",
     "id": "6d4d57d3-2e05-4ec4-9617-1d1cd3971035",
     "name": "Jane Pauley Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartJPCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartJPCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTJPCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTJPCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/jewishfreeclinic/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/JEWISHFREECLINIC/api/FHIR/R4/",
     "id": "89a70f53-ad73-447d-aab2-9d50ac127fce",
     "name": "Jewish Community Free Clinic",
-    "token": "https://webprd.ochin.org/prd-fhir/jewishfreeclinic/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/jewishfreeclinic/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/JEWISHFREECLINIC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/JEWISHFREECLINIC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2640,11 +2824,11 @@
     "managingOrganization": "Johns Hopkins Medicine"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/jordanvalleymychart/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/JORDANVALLEYMYCHART/api/FHIR/R4/",
     "id": "e9912fd8-fc4e-4b19-a830-d0ba13c04f87",
     "name": "Jordan Valley Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/jordanvalleymychart/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/jordanvalleymychart/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/JORDANVALLEYMYCHART/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/JORDANVALLEYMYCHART/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2744,6 +2928,14 @@
     "managingOrganization": "Kaiser Permanente - Washington"
   },
   {
+    "url": "https://epicproxy.et1455.epichosted.com/APIProxyPRD/api/FHIR/R4/",
+    "id": "374e42cf-4d06-4407-9a7f-a2b27553d8ea",
+    "name": "Kaleida",
+    "token": "https://epicproxy.et1455.epichosted.com/APIProxyPRD/oauth2/token",
+    "authorize": "https://epicproxy.et1455.epichosted.com/APIProxyPRD/oauth2/authorize",
+    "managingOrganization": "Kaleida Health"
+  },
+  {
     "url": "https://ssrx.ksnet.com/FHIRproxy/MKO/api/FHIR/R4/",
     "id": "f7d4421e-5f3a-4f2a-a51e-9d008eb013fc",
     "name": "Kelsey-Seybold",
@@ -2760,11 +2952,11 @@
     "managingOrganization": "Kennedy Krieger Institute"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartKCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTKCHC/api/FHIR/R4/",
     "id": "c92cf7f3-83da-4af0-85b1-93b4d2e3e6d7",
     "name": "Kenosha Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartKCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartKCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTKCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTKCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2800,43 +2992,43 @@
     "managingOrganization": "Memorial Hermann"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartKingCounty/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTKINGCOUNTY/api/FHIR/R4/",
     "id": "97f9ad39-0469-4e9a-88bf-097d50bfc80e",
     "name": "King County Public Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartKingCounty/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartKingCounty/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTKINGCOUNTY/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTKINGCOUNTY/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartkintegra/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTKINTEGRA/api/FHIR/R4/",
     "id": "331e1a51-6d4e-44ce-8145-8c465ec5d32c",
     "name": "Kintegra Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartkintegra/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartkintegra/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTKINTEGRA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTKINTEGRA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartkokwelwellness/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTKOKWELWELLNESS/api/FHIR/R4/",
     "id": "d1877b44-1874-4b06-b30f-36c57a53d8ad",
     "name": "Ko-Kwel Wellness Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartkokwelwellness/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartkokwelwellness/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTKOKWELWELLNESS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTKOKWELWELLNESS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartLaClinicaHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLACLINICAHEALTH/api/FHIR/R4/",
     "id": "40ba1375-52e8-4f05-9e3e-63fc4923204f",
     "name": "La Clinica",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartLaClinicaHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartLaClinicaHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLACLINICAHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLACLINICAHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartlclr/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLCLR/api/FHIR/R4/",
     "id": "f26365b5-40be-404a-8e15-f52e8c769c9c",
     "name": "La Clinica",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartlclr/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartlclr/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLCLR/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLCLR/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2848,19 +3040,27 @@
     "managingOrganization": "Shannon Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartlpchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLPCHC/api/FHIR/R4/",
     "id": "0b417836-850b-4ebc-8e51-dd4f9542fc66",
     "name": "La Pine Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartlpchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartlpchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLPCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLPCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartlbcc/api/FHIR/R4/",
+    "url": "https://epicsoap.wellstar.org/fhirproxy/api/FHIR/R4/",
+    "id": "f502777e-6939-4529-902d-29aa57a1d27e",
+    "name": "LaGrange Internal Medicine",
+    "token": "https://epicsoap.wellstar.org/fhirproxy/oauth2/token",
+    "authorize": "https://epicsoap.wellstar.org/fhirproxy/oauth2/authorize",
+    "managingOrganization": "Wellstar"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLBCC/api/FHIR/R4/",
     "id": "cc003c73-b801-492f-bd0b-08ab7e1412d2",
     "name": "Laguna Beach",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartlbcc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartlbcc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLBCC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLBCC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2880,27 +3080,35 @@
     "managingOrganization": "Lakeland Regional Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartlchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLCHC/api/FHIR/R4/",
     "id": "38c11012-2a10-4da2-820b-4682c1295d51",
     "name": "Lakeshore Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartlchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartlchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartlhs/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLHS/api/FHIR/R4/",
     "id": "af4cb028-ab02-47a0-8c10-670ff85f0dd2",
     "name": "Lakewood Health System",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartlhs/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartlhs/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mylawndale/api/FHIR/R4/",
+    "url": "https://epicproxy.lghealth.org/fhirproxy/api/FHIR/R4/",
+    "id": "3988e5f9-7163-48c4-91ee-abe14301850d",
+    "name": "Lancaster",
+    "token": "https://epicproxy.lghealth.org/fhirproxy/oauth2/token",
+    "authorize": "https://epicproxy.lghealth.org/fhirproxy/oauth2/authorize",
+    "managingOrganization": "Lancaster General Hospital"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYLAWNDALE/api/FHIR/R4/",
     "id": "6e99629f-6fc9-430c-937f-c6adbd6d3639",
     "name": "Lawndale Christian Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mylawndale/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mylawndale/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYLAWNDALE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYLAWNDALE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -2944,11 +3152,11 @@
     "managingOrganization": "Licking Memorial Health Systems"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartllmc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLLMC/api/FHIR/R4/",
     "id": "286fd891-b479-4187-b795-909f2e79748f",
     "name": "LifeLong Medical",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartllmc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartllmc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLLMC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLLMC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3008,11 +3216,11 @@
     "managingOrganization": "Ardent"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/LowerLightsHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/LOWERLIGHTSHEALTH/api/FHIR/R4/",
     "id": "dda9a169-5518-40a6-a1d6-69f839c685cb",
     "name": "Lower Lights Christian Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/LowerLightsHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/LowerLightsHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/LOWERLIGHTSHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/LOWERLIGHTSHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3032,11 +3240,11 @@
     "managingOrganization": "Luminis Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartlths/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLTHS/api/FHIR/R4/",
     "id": "54f2952c-2e1f-4398-ab85-2d04c1b1dc71",
     "name": "Lummi Tribal Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartlths/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartlths/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLTHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLTHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3048,11 +3256,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartlmhs/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTLMHS/api/FHIR/R4/",
     "id": "5828fe4b-dcac-4edb-8133-dfcc828572d6",
     "name": "Lyon Martin",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartlmhs/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartlmhs/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTLMHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTLMHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3061,7 +3269,7 @@
     "name": "M Health Fairview",
     "token": "https://sfd.fairview.org/FHIR/oauth2/token",
     "authorize": "https://sfd.fairview.org/FHIR/oauth2/authorize",
-    "managingOrganization": "M Health Fairview"
+    "managingOrganization": "Fairview"
   },
   {
     "url": "https://epicproxy.et1326.epichosted.com/FHIRProxy/MHCC/api/FHIR/R4/",
@@ -3120,11 +3328,11 @@
     "managingOrganization": "MaineHealth"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartMCHCC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMCHCC/api/FHIR/R4/",
     "id": "ccf89ec9-403d-4596-9a51-e7050bd46b10",
     "name": "Maple City Health Care Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartMCHCC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartMCHCC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMCHCC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMCHCC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3136,11 +3344,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartMCC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMCC/api/FHIR/R4/",
     "id": "9318cdd4-c0e8-425e-9a57-a493da7a4ccc",
     "name": "Marin Community Clinic",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartMCC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartMCC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMCC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMCC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3184,16 +3392,16 @@
     "managingOrganization": "Mayo Clinic"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartmc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMC/api/FHIR/R4/",
     "id": "171317c3-5561-4584-867f-b9ee1b3d6c5f",
     "name": "MCHC Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartmc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartmc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
     "url": "https://epicproxy.et1267.epichosted.com/FHIRProxy/api/FHIR/R4/",
-    "id": "d733842b-7f41-415e-bd92-e1e9a3b118f8",
+    "id": "352ed956-50bb-4213-a360-10cccd0e31c0",
     "name": "McLeod Health",
     "token": "https://epicproxy.et1267.epichosted.com/FHIRProxy/oauth2/token",
     "authorize": "https://epicproxy.et1267.epichosted.com/FHIRProxy/oauth2/authorize",
@@ -3206,6 +3414,14 @@
     "token": "https://eprescribe-p.medisys.org/fhir-prd/MED/oauth2/token",
     "authorize": "https://eprescribe-p.medisys.org/fhir-prd/MED/oauth2/authorize",
     "managingOrganization": "MediSys Health Network"
+  },
+  {
+    "url": "https://epicfe.unch.unc.edu/FHIR/api/FHIR/R4/",
+    "id": "e10495a6-6344-4f49-8af0-c2fd84d7351d",
+    "name": "MedNorth",
+    "token": "https://epicfe.unch.unc.edu/FHIR/oauth2/token",
+    "authorize": "https://epicfe.unch.unc.edu/FHIR/oauth2/authorize",
+    "managingOrganization": "UNC Health Care System"
   },
   {
     "url": "https://memorialhealthfhirprd.app.medcity.net/fhir-proxy/api/FHIR/R4/",
@@ -3248,19 +3464,11 @@
     "managingOrganization": "MemorialCare Health System (CA)"
   },
   {
-    "url": "https://epicproxy.et1206.epichosted.com/FHIRProxy/api/FHIR/R4/",
-    "id": "e9851f22-f0df-436f-a5e4-c2c352681edf",
-    "name": "Men's Mental Health",
-    "token": "https://epicproxy.et1206.epichosted.com/FHIRProxy/oauth2/token",
-    "authorize": "https://epicproxy.et1206.epichosted.com/FHIRProxy/oauth2/authorize",
-    "managingOrganization": "Baptist Health (Jacksonville"
-  },
-  {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsjmc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSJMC/api/FHIR/R4/",
     "id": "f0826d9b-c5be-4f27-8e29-32796b6cf276",
     "name": "Mercy Care",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsjmc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsjmc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSJMC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSJMC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3328,6 +3536,14 @@
     "managingOrganization": "Mercyhealth"
   },
   {
+    "url": "https://epicproxy.et1124.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "34ed8ff7-3051-4c8e-bdd7-7ff00e18b57a",
+    "name": "Middlesex Health",
+    "token": "https://epicproxy.et1124.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1124.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "Middlesex Health"
+  },
+  {
     "url": "https://epicproxy.et1329.epichosted.com/APIProxyPRD/HOME/api/FHIR/R4/",
     "id": "224418c9-a709-44c3-84c3-77051022c617",
     "name": "Midwestern University Clinics",
@@ -3336,19 +3552,19 @@
     "managingOrganization": "Midwestern University"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartMHS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMHS/api/FHIR/R4/",
     "id": "ff81a1a7-ef93-4e13-8e07-399c0ca99a8f",
     "name": "Milwaukee Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartMHS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartMHS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartMinidoka/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMINIDOKA/api/FHIR/R4/",
     "id": "1c49c5c3-16e7-458e-bad4-28a40e860111",
     "name": "Minidoka Memorial Hospital",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartMinidoka/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartMinidoka/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMINIDOKA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMINIDOKA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3360,7 +3576,7 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://retailepicfhir.cvshealth.com/fhirproxy/api/FHIR/R4/",
+    "url": "https://retailepicfhir.cvshealth.com/FhirProxy/api/FHIR/R4/",
     "id": "7fe201e2-227d-4b0e-9ece-b6d2d08da72d",
     "name": "Minute Clinic",
     "token": "https://retailepicfhir.cvshealth.com/FhirProxy/oauth2/token",
@@ -3368,11 +3584,11 @@
     "managingOrganization": "CVS Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartMNHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMNHC/api/FHIR/R4/",
     "id": "eed1e616-4947-4fa1-8a86-4d884fc91cc7",
     "name": "Mission Neighborhood Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartMNHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartMNHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMNHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMNHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3384,11 +3600,11 @@
     "managingOrganization": "The University of Mississippi Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/missouriozarks/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MISSOURIOZARKS/api/FHIR/R4/",
     "id": "116c2627-484d-4cf2-b5f1-248904bcaf65",
     "name": "Missouri Ozarks",
-    "token": "https://webprd.ochin.org/prd-fhir/missouriozarks/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/missouriozarks/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MISSOURIOZARKS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MISSOURIOZARKS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3424,11 +3640,11 @@
     "managingOrganization": "Montefiore Health System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartMCHD/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMCHD/api/FHIR/R4/",
     "id": "34778d2c-0856-43ce-a606-335559dfb057",
     "name": "Monterey County Health Department Clinic Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartMCHD/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartMCHD/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMCHD/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMCHD/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3448,12 +3664,28 @@
     "managingOrganization": "Memorial Hermann"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartmosaic/api/FHIR/R4/",
+    "url": "https://epicproxy.et1274.epichosted.com/FHIRproxy/api/FHIR/R4/",
+    "id": "abaf5dbc-057b-4a59-b2fb-04883e4c473e",
+    "name": "Mosaic Life Care",
+    "token": "https://epicproxy.et1274.epichosted.com/FHIRproxy/oauth2/token",
+    "authorize": "https://epicproxy.et1274.epichosted.com/FHIRproxy/oauth2/authorize",
+    "managingOrganization": "Mosaic Life Care"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMOSAIC/api/FHIR/R4/",
     "id": "5935f42b-15e2-4a9d-aed1-b0e53f4f54e9",
     "name": "Mosaic Medical",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartmosaic/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartmosaic/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMOSAIC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMOSAIC/oauth2/authorize",
     "managingOrganization": "OCHIN"
+  },
+  {
+    "url": "https://arr.mountnittany.org/FHIR/api/FHIR/R4/",
+    "id": "a1a61458-6616-4502-bf70-55a7e4fcbcb8",
+    "name": "Mount Nittany Health",
+    "token": "https://arr.mountnittany.org/FHIR/oauth2/token",
+    "authorize": "https://arr.mountnittany.org/FHIR/oauth2/authorize",
+    "managingOrganization": "Mount Nittany Health System"
   },
   {
     "url": "https://epicfhir.msmc.com/proxysite-prd/api/FHIR/R4/",
@@ -3464,11 +3696,11 @@
     "managingOrganization": "Mount Sinai Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mountainvalleyshealthcenters/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MOUNTAINVALLEYSHEALTHCENTERS/api/FHIR/R4/",
     "id": "a7383ffe-68f0-4143-9798-7e473c0c5d2a",
     "name": "Mountain Valleys Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/mountainvalleyshealthcenters/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mountainvalleyshealthcenters/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MOUNTAINVALLEYSHEALTHCENTERS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MOUNTAINVALLEYSHEALTHCENTERS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3496,11 +3728,11 @@
     "managingOrganization": "OrthoVirginia"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartmultco/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTMULTCO/api/FHIR/R4/",
     "id": "effca2a5-ceca-45a4-9507-ebb70295eef4",
     "name": "Multnomah County Health Department",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartmultco/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartmultco/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTMULTCO/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTMULTCO/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3552,11 +3784,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartnahc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTNAHC/api/FHIR/R4/",
     "id": "252af6f0-d175-4daf-8a44-1331ce346228",
     "name": "Native American Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartnahc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartnahc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTNAHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTNAHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3568,19 +3800,19 @@
     "managingOrganization": "NCH Healthcare System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/NehalemBayHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/NEHALEMBAYHEALTH/api/FHIR/R4/",
     "id": "e6c650f2-a6d9-416f-a4fd-0023858fe54a",
     "name": "Nehalem Bay Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/NehalemBayHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/NehalemBayHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/NEHALEMBAYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/NEHALEMBAYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartnch/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTNCH/api/FHIR/R4/",
     "id": "5f9adcdb-d88a-4f9d-a7da-ffc8b93b116f",
     "name": "Neighborcare Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartnch/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartnch/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTNCH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTNCH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3600,11 +3832,11 @@
     "managingOrganization": "Garden Plot"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartnhc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTNHC/api/FHIR/R4/",
     "id": "defb13f2-f2f9-4cbc-9760-a83b075df112",
     "name": "Neighborhood Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartnhc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartnhc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTNHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTNHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3616,11 +3848,11 @@
     "managingOrganization": "Nemours"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/nvhc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/NVHC/api/FHIR/R4/",
     "id": "c65421f0-1ce8-4dbf-8e0c-7701f20b0391",
     "name": "Nevada Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/nvhc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/nvhc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/NVHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/NVHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3632,6 +3864,14 @@
     "managingOrganization": "Bryan Health"
   },
   {
+    "url": "https://interconnect.lcmchealth.org/FHIR/LAK/api/FHIR/R4/",
+    "id": "d3d9ea7e-0214-4830-9d98-0798f389fa4b",
+    "name": "New Orleans Nephrology Associates",
+    "token": "https://interconnect.lcmchealth.org/FHIR/LAK/oauth2/token",
+    "authorize": "https://interconnect.lcmchealth.org/FHIR/LAK/oauth2/authorize",
+    "managingOrganization": "LCMC Health"
+  },
+  {
     "url": "https://epicproxy-pub.et1089.epichosted.com/FHIRProxy/api/FHIR/R4/",
     "id": "65d9e6a1-fdd4-eb11-9149-001dd8b71f19",
     "name": "New York Presbyterian",
@@ -3640,11 +3880,11 @@
     "managingOrganization": "New York Consortium"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/NOAHHelps/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/NOAHHELPS/api/FHIR/R4/",
     "id": "61374ea0-4019-4482-af4a-69d0fd606995",
     "name": "NOAH",
-    "token": "https://webprd.ochin.org/prd-fhir/NOAHHelps/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/NOAHHelps/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/NOAHHELPS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/NOAHHELPS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3664,11 +3904,11 @@
     "managingOrganization": "North Carolina Department of Health and Human Services"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartNorthlakes/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTNORTHLAKES/api/FHIR/R4/",
     "id": "f55261cf-78e3-409c-a55f-2cf4d151c8de",
     "name": "North Lakes",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartNorthlakes/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartNorthlakes/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTNORTHLAKES/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTNORTHLAKES/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3688,6 +3928,14 @@
     "managingOrganization": "North Oaks Health"
   },
   {
+    "url": "https://scproxy.gundersenhealth.org/FHIRARR/api/FHIR/R4/",
+    "id": "7de75e0c-f905-4136-b53f-871da5e2c670",
+    "name": "NorthEast Wisconsin Community Clinic",
+    "token": "https://scproxy.gundersenhealth.org/FHIRARR/oauth2/token",
+    "authorize": "https://scproxy.gundersenhealth.org/FHIRARR/oauth2/authorize",
+    "managingOrganization": "Emplify Health"
+  },
+  {
     "url": "https://call.api.northwell.io/epic-proxy/api/fhir/R4/",
     "id": "1a5fe784-078b-ef11-91a4-0050568bc890",
     "name": "Northwell Health",
@@ -3697,7 +3945,7 @@
   },
   {
     "url": "https://nmepicproxy.nm.org/FHIR-PRD/api/FHIR/R4/",
-    "id": "a80f0458-81ff-49fa-a7bf-5fa9452205c5",
+    "id": "942c53ef-7944-44c9-b9f2-d4c21ab7187b",
     "name": "Northwestern Medicine",
     "token": "https://nmepicproxy.nm.org/FHIR-PRD/oauth2/token",
     "authorize": "https://nmepicproxy.nm.org/FHIR-PRD/oauth2/authorize",
@@ -3816,11 +4064,11 @@
     "managingOrganization": "Olmsted Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartol/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTOL/api/FHIR/R4/",
     "id": "b7858386-6269-4682-b824-c3196c09bbdf",
     "name": "On Lok",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartol/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartol/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTOL/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTOL/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3832,28 +4080,20 @@
     "managingOrganization": "One Brooklyn Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartoch/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTOCH/api/FHIR/R4/",
     "id": "f459ac72-2e1a-4de4-ba39-8b7e0095f395",
     "name": "One Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartoch/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartoch/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTOCH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTOCH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartochor/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTOCHOR/api/FHIR/R4/",
     "id": "a0018c3b-db8f-4798-9900-f1219275c4ae",
     "name": "One Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartochor/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartochor/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTOCHOR/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTOCHOR/oauth2/authorize",
     "managingOrganization": "OCHIN"
-  },
-  {
-    "url": "https://ocsoapprd.nebraskamed.com/FHIR-PRD/api/FHIR/R4/",
-    "id": "8361a289-a5f8-4876-bced-f748aac41997",
-    "name": "OneChart",
-    "token": "https://ocsoapprd.nebraskamed.com/FHIR-PRD/oauth2/token",
-    "authorize": "https://ocsoapprd.nebraskamed.com/FHIR-PRD/oauth2/authorize",
-    "managingOrganization": "Nebraska Medicine"
   },
   {
     "url": "https://yrmccare1.yumaregional.org/FHIR/Onvida/api/FHIR/R4/",
@@ -3872,11 +4112,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartopendoor/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTOPENDOOR/api/FHIR/R4/",
     "id": "e56ba70e-a498-4a5e-9bec-ad3c93c6d452",
     "name": "OpenDoor Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartopendoor/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartopendoor/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTOPENDOOR/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTOPENDOOR/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3888,11 +4128,11 @@
     "managingOrganization": "Memorial Hermann"
   },
   {
-    "url": "https://fhir.myeverettclinic.com/fhir/EVERETT/api/FHIR/R4/",
-    "id": "29bcd6dc-be5b-42f8-a707-edbf97359fa7",
+    "url": "https://fhir.myeverettclinic.com/fhir/api/FHIR/R4/",
+    "id": "c236e457-082b-45a7-b7c7-35e3e2ae4cac",
     "name": "Optum Care Washington",
-    "token": "https://fhir.myeverettclinic.com/fhir/EVERETT/oauth2/token",
-    "authorize": "https://fhir.myeverettclinic.com/fhir/EVERETT/oauth2/authorize",
+    "token": "https://fhir.myeverettclinic.com/fhir/oauth2/token",
+    "authorize": "https://fhir.myeverettclinic.com/fhir/oauth2/authorize",
     "managingOrganization": "Optum Care Washington"
   },
   {
@@ -3902,14 +4142,6 @@
     "token": "https://epicproxy.et1038.epichosted.com/FHIRProxy/oauth2/token",
     "authorize": "https://epicproxy.et1038.epichosted.com/FHIRProxy/oauth2/authorize",
     "managingOrganization": "EPIC Management"
-  },
-  {
-    "url": "https://epicproxy.et1131.epichosted.com/FHIRProxy/api/FHIR/R4/",
-    "id": "7ba697da-ed93-4c17-8d3a-dce06c85024a",
-    "name": "Orlando Health",
-    "token": "https://epicproxy.et1131.epichosted.com/FHIRProxy/oauth2/token",
-    "authorize": "https://epicproxy.et1131.epichosted.com/FHIRProxy/oauth2/authorize",
-    "managingOrganization": "Orlando Health"
   },
   {
     "url": "https://epwebapps.orthocarolina.com/fhir-prd/api/FHIR/R4/",
@@ -3936,11 +4168,11 @@
     "managingOrganization": "Muscogee (Creek) Nation Department of Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/omc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/OMC/api/FHIR/R4/",
     "id": "b09e4be7-8cad-4fa5-ae93-e021770d42fc",
     "name": "Osceola Medical Center",
-    "token": "https://webprd.ochin.org/prd-fhir/omc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/omc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/OMC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/OMC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3952,11 +4184,11 @@
     "managingOrganization": "OU Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartochs/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTOCHS/api/FHIR/R4/",
     "id": "14250769-6f9d-4d01-9ef8-14f4ca5d9bcb",
     "name": "Outer Cape Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartochs/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartochs/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTOCHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTOCHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -3984,11 +4216,11 @@
     "managingOrganization": "Owensboro Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartpuo/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTPUO/api/FHIR/R4/",
     "id": "22f3dc4f-33b4-412e-9d33-51ad8a472e9b",
     "name": "Pacific University Oregon",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartpuo/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartpuo/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTPUO/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTPUO/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4032,11 +4264,11 @@
     "managingOrganization": "PeaceHealth"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/PeakVista/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/PEAKVISTA/api/FHIR/R4/",
     "id": "3278e7cb-487a-49be-a8a8-cec88f6f6d73",
     "name": "Peak Vista",
-    "token": "https://webprd.ochin.org/prd-fhir/PeakVista/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/PeakVista/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/PEAKVISTA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/PEAKVISTA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4064,11 +4296,19 @@
     "managingOrganization": "Pediatric Physicians Organization at Childrens"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartaustinpcc/api/FHIR/R4/",
+    "url": "https://ssproxy.pennhealth.com/PRD-FHIR/api/FHIR/R4/",
+    "id": "a313749f-d49d-4fb3-aa3b-5b62ab5c6f0e",
+    "name": "Penn Medicine",
+    "token": "https://ssproxy.pennhealth.com/PRD-FHIR/oauth2/token",
+    "authorize": "https://ssproxy.pennhealth.com/PRD-FHIR/oauth2/authorize",
+    "managingOrganization": "University of Pennsylvania Health System"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTAUSTINPCC/api/FHIR/R4/",
     "id": "79dd38b2-6770-4c7b-aac8-2b6597895cbf",
     "name": "People's Community Clinic",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartaustinpcc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartaustinpcc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTAUSTINPCC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTAUSTINPCC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4080,11 +4320,11 @@
     "managingOrganization": "UC San Diego Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/PHealthCenter/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/PHEALTHCENTER/api/FHIR/R4/",
     "id": "5b3a305a-e8b4-4d53-abad-429332525ba0",
     "name": "Petaluma Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/PHealthCenter/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/PHealthCenter/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/PHEALTHCENTER/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/PHEALTHCENTER/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4128,11 +4368,11 @@
     "managingOrganization": "Garden Plot"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartPHS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTPHS/api/FHIR/R4/",
     "id": "79bb1597-c752-4988-bd4e-8570b1624ae4",
     "name": "Pines Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartPHS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartPHS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTPHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTPHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4149,14 +4389,14 @@
     "name": "Planned Parenthood",
     "token": "https://epicproxy.et1154.epichosted.com/FHIRProxy/oauth2/token",
     "authorize": "https://epicproxy.et1154.epichosted.com/FHIRProxy/oauth2/authorize",
-    "managingOrganization": "Planned Parenthood"
+    "managingOrganization": "BetterHealth"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartppnorcal/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTPPNORCAL/api/FHIR/R4/",
     "id": "f831bb53-2e36-4269-8960-6d26db324308",
     "name": "Planned Parenthood of Northern California",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartppnorcal/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartppnorcal/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTPPNORCAL/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTPPNORCAL/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4168,11 +4408,11 @@
     "managingOrganization": "Ardent"
   },
   {
-    "url": "https://webproxy.comhs.org/FHIR/api/FHIR/R4/",
+    "url": "https://webproxy.comhs.org/FHIR/POWERS/api/FHIR/R4/",
     "id": "df195a03-eeb0-40aa-b899-7c2c37dfbbbb",
     "name": "Powers Health",
-    "token": "https://webproxy.comhs.org/FHIR/oauth2/token",
-    "authorize": "https://webproxy.comhs.org/FHIR/oauth2/authorize",
+    "token": "https://webproxy.comhs.org/FHIR/POWERS/oauth2/token",
+    "authorize": "https://webproxy.comhs.org/FHIR/POWERS/oauth2/authorize",
     "managingOrganization": "Powers Health"
   },
   {
@@ -4200,11 +4440,11 @@
     "managingOrganization": "Premise Health"
   },
   {
-    "url": "https://epicfhir.phs.org/FHIR/api/FHIR/R4/",
+    "url": "https://epicfhir.phs.org/FHIR/PHSMAIN/api/FHIR/R4/",
     "id": "e60e87d9-c514-47bc-adfb-410eda749a6d",
     "name": "Presbyterian Healthcare Services",
-    "token": "https://epicfhir.phs.org/FHIR/oauth2/token",
-    "authorize": "https://epicfhir.phs.org/FHIR/oauth2/authorize",
+    "token": "https://epicfhir.phs.org/FHIR/PHSMAIN/oauth2/token",
+    "authorize": "https://epicfhir.phs.org/FHIR/PHSMAIN/oauth2/authorize",
     "managingOrganization": "Presbyterian Healthcare Services"
   },
   {
@@ -4216,11 +4456,11 @@
     "managingOrganization": "Memorial Hermann"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/phciowa/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/PHCIOWA/api/FHIR/R4/",
     "id": "4dc97fb4-baae-42c8-9a4d-0a7d92acf3f7",
     "name": "Primary Health Care",
-    "token": "https://webprd.ochin.org/prd-fhir/phciowa/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/phciowa/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/PHCIOWA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/PHCIOWA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4240,11 +4480,11 @@
     "managingOrganization": "Prime Healthcare"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartpgchd/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTPGCHD/api/FHIR/R4/",
     "id": "990bf227-9ba4-4460-83ea-0b89682e16ee",
     "name": "Prince George's County Health Department",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartpgchd/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartpgchd/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTPGCHD/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTPGCHD/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4256,12 +4496,20 @@
     "managingOrganization": "Prisma Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/ProgressiveCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/PROGRESSIVECHC/api/FHIR/R4/",
     "id": "f618c7ec-230a-4732-bad0-2579e0d62c93",
     "name": "Progressive Community Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/ProgressiveCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/ProgressiveCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/PROGRESSIVECHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/PROGRESSIVECHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
+  },
+  {
+    "url": "https://soap.phci.org/Interconnect-FHIR/api/FHIR/R4/",
+    "id": "3b658306-c76b-45e4-902f-fea01be33f0f",
+    "name": "ProHealth Care",
+    "token": "https://soap.phci.org/Interconnect-FHIR/oauth2/token",
+    "authorize": "https://soap.phci.org/Interconnect-FHIR/oauth2/authorize",
+    "managingOrganization": "ProHealth Care"
   },
   {
     "url": "https://fhirprd.reliantmedicalgroup.org/FHIRPRD/api/FHIR/R4/",
@@ -4280,11 +4528,11 @@
     "managingOrganization": "ProMedica"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyPHMCHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYPHMCHEALTH/api/FHIR/R4/",
     "id": "eb022a3c-7784-4ae4-919e-66a9be435308",
     "name": "Public Health Management Corporation",
-    "token": "https://webprd.ochin.org/prd-fhir/MyPHMCHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyPHMCHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYPHMCHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYPHMCHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4296,11 +4544,11 @@
     "managingOrganization": "QuadMed"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartQOL/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTQOL/api/FHIR/R4/",
     "id": "150f68db-b160-4d8e-b7b8-f5198c442c16",
     "name": "Quality of Life Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartQOL/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartQOL/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTQOL/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTQOL/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4320,11 +4568,11 @@
     "managingOrganization": "The Queen's Health Systems"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartRadiantHealthCenters/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTRADIANTHEALTHCENTERS/api/FHIR/R4/",
     "id": "fb4f5dac-7d97-45c4-a416-eb8e48421c0e",
     "name": "Radiant Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartRadiantHealthCenters/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartRadiantHealthCenters/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTRADIANTHEALTHCENTERS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTRADIANTHEALTHCENTERS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4336,11 +4584,11 @@
     "managingOrganization": "Rady Children's Hospital San Diego"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartrfhc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTRFHC/api/FHIR/R4/",
     "id": "476d6f04-eefc-40ee-be02-eef15c782692",
     "name": "Ravenswood Family Health Network",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartrfhc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartrfhc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTRFHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTRFHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4384,36 +4632,44 @@
     "managingOrganization": "Garden Plot"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/riverhillshealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/RIVERHILLSHEALTH/api/FHIR/R4/",
     "id": "11ddfe31-3566-4897-a961-8f69487294bf",
     "name": "River Hills Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/riverhillshealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/riverhillshealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/RIVERHILLSHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/RIVERHILLSHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/rphc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/RPHC/api/FHIR/R4/",
     "id": "34b1e46f-fe38-4663-a823-7cf8e80f6763",
     "name": "River People Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/rphc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/rphc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/RPHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/RPHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartRVPCS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTRVPCS/api/FHIR/R4/",
     "id": "37def8b6-816e-4b9a-bf7f-2f72a6c3cad9",
     "name": "River Valley Primary Care Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartRVPCS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartRVPCS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTRVPCS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTRVPCS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/RCHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/RCHEALTH/api/FHIR/R4/",
     "id": "c923f9b1-b84b-4a3c-ae95-64848f09da3c",
     "name": "Riverland Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/RCHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/RCHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/RCHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/RCHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "a1fd6a8b-428c-443f-b0fd-5f9237375bfe",
+    "name": "River's Edge Hospital & Clinic",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://ep-rpfg.rivhs.com/Interconnect-FHIR-PRD/RHSMYCHART/api/FHIR/R4/",
@@ -4448,11 +4704,11 @@
     "managingOrganization": "Mercy"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/rwhealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/RWHEALTH/api/FHIR/R4/",
     "id": "f675298f-2f52-4281-a79e-62f5f074dd76",
     "name": "Riverwood Healthcare Center",
-    "token": "https://webprd.ochin.org/prd-fhir/rwhealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/rwhealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/RWHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/RWHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4464,11 +4720,19 @@
     "managingOrganization": "Rochester Regional Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartrogue/api/FHIR/R4/",
+    "url": "https://ukepicproxy.mc.uky.edu/Interconnect-PRD-OAuth2/RC/api/FHIR/R4/",
+    "id": "f5bc9cf7-ff77-4dc8-8339-b4f414fcafde",
+    "name": "Rockcastle Regional",
+    "token": "https://ukepicproxy.mc.uky.edu/Interconnect-PRD-OAuth2/RC/oauth2/token",
+    "authorize": "https://ukepicproxy.mc.uky.edu/Interconnect-PRD-OAuth2/RC/oauth2/authorize",
+    "managingOrganization": "UK HealthCare"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTROGUE/api/FHIR/R4/",
     "id": "6a5c2da3-aaa4-4fd0-9d0c-77217b8ba6bd",
     "name": "Rogue Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartrogue/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartrogue/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTROGUE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTROGUE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4512,19 +4776,19 @@
     "managingOrganization": "RWJBarnabas Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsaban/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSABAN/api/FHIR/R4/",
     "id": "0bcc7152-3cdd-42b7-8bae-c91cec40361a",
     "name": "Saban",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsaban/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsaban/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSABAN/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSABAN/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/scph/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SCPH/api/FHIR/R4/",
     "id": "1dc0c5e9-205a-4687-9175-395a39f55697",
     "name": "Sacramento County Public Health",
-    "token": "https://webprd.ochin.org/prd-fhir/scph/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/scph/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SCPH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SCPH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4560,19 +4824,19 @@
     "managingOrganization": "Samaritan Health Services"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSFSOS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSFSOS/api/FHIR/R4/",
     "id": "76113b91-cd3d-488e-bcc2-7f68f065ff37",
     "name": "San Francisco Community Clinic Consortium",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSFSOS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSFSOS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSFSOS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSFSOS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSFCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSFCHC/api/FHIR/R4/",
     "id": "be0ae9b3-9f6b-48cc-a6d4-ec889361d8d3",
     "name": "San Francisco Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSFCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSFCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSFCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSFCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4592,6 +4856,14 @@
     "managingOrganization": "OCHIN"
   },
   {
+    "url": "https://epicproxy.et1327.epichosted.com/FHIRProxy/api/FHIR/R4/",
+    "id": "cdde6aec-3491-4cc8-a58b-08dc28c0c511",
+    "name": "San Ysidro Health",
+    "token": "https://epicproxy.et1327.epichosted.com/FHIRProxy/oauth2/token",
+    "authorize": "https://epicproxy.et1327.epichosted.com/FHIRProxy/oauth2/authorize",
+    "managingOrganization": "San Ysidro Health"
+  },
+  {
     "url": "https://wavesurescripts.sansumclinic.org/FHIR/api/FHIR/R4/",
     "id": "fa446860-aed3-4609-a7c5-3ac7c3a44ea9",
     "name": "Sansum",
@@ -4601,7 +4873,7 @@
   },
   {
     "url": "https://scvhhsfhir.sccgov.org/interconnect-oauth2/api/FHIR/R4/",
-    "id": "f39526e7-c2f6-46bd-b05c-5de6ea257cd6",
+    "id": "7aa5f4f5-7f66-4ad9-a4d5-269b0e33bd7a",
     "name": "Santa Clara",
     "token": "https://scvhhsfhir.sccgov.org/interconnect-oauth2/oauth2/token",
     "authorize": "https://scvhhsfhir.sccgov.org/interconnect-oauth2/oauth2/authorize",
@@ -4616,11 +4888,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/SRHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SRHEALTH/api/FHIR/R4/",
     "id": "1841f160-5431-4082-9cae-16f285088998",
     "name": "Santa Rosa Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/SRHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/SRHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SRHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SRHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4632,19 +4904,19 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/Scenicrivershealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SCENICRIVERSHEALTH/api/FHIR/R4/",
     "id": "8194bcfd-1cc5-4f35-b29e-5ee9cf22ab3f",
     "name": "Scenic Rivers Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/Scenicrivershealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/Scenicrivershealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SCENICRIVERSHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SCENICRIVERSHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSHC/api/FHIR/R4/",
     "id": "b572498d-fd9c-451c-9a89-08a631872621",
     "name": "School Health Clinics of Santa Clara County",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4664,19 +4936,19 @@
     "managingOrganization": "Seattle Children's Hospital"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsihb/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSIHB/api/FHIR/R4/",
     "id": "627ae26e-83ae-4209-bb4a-15049219d45d",
     "name": "Seattle Indian Health Board",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsihb/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsihb/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSIHB/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSIHB/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSeattleroots/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSEATTLEROOTS/api/FHIR/R4/",
     "id": "5e58c821-47dd-4cd8-9315-c3b66f23e0b5",
     "name": "Seattle Roots Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSeattleroots/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSeattleroots/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSEATTLEROOTS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSEATTLEROOTS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4720,11 +4992,11 @@
     "managingOrganization": "Shannon Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsos/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSOS/api/FHIR/R4/",
     "id": "79486f9b-d97f-4f20-8f78-2271db7ad2ac",
     "name": "Share Our Selves",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsos/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsos/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSOS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSOS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4744,11 +5016,11 @@
     "managingOrganization": "Shriners Children's"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartSH/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSH/api/FHIR/R4/",
     "id": "58ea54d9-449d-4d3c-b2b4-277c72584782",
     "name": "Signature Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartSH/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartSH/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4776,19 +5048,19 @@
     "managingOrganization": "Singing River Health System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/slandchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SLANDCHC/api/FHIR/R4/",
     "id": "0174954e-13ae-494a-bd4c-5c3f30bf0b91",
     "name": "Siouxland Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/slandchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/slandchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SLANDCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SLANDCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartschc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSCHC/api/FHIR/R4/",
     "id": "56e17195-c196-40a2-8f84-99bc094e8286",
     "name": "Sixteenth Street",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartschc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartschc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4824,19 +5096,19 @@
     "managingOrganization": "Overlake Hospital Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartshchd/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSHCHD/api/FHIR/R4/",
     "id": "610a5116-33a4-4fc7-b8cb-db44b9bcbc2a",
     "name": "SoHum Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartshchd/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartshchd/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSHCHD/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSHCHD/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/SolanoCountyHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SOLANOCOUNTYHEALTH/api/FHIR/R4/",
     "id": "cd08a7e5-1b04-46ee-bbc3-4d4e4b66b133",
     "name": "Solano County",
-    "token": "https://webprd.ochin.org/prd-fhir/SolanoCountyHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/SolanoCountyHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SOLANOCOUNTYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SOLANOCOUNTYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4856,19 +5128,19 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/svchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SVCHC/api/FHIR/R4/",
     "id": "02d72de0-e085-4b5f-a04f-5df361b24f44",
     "name": "Sonoma Valley Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/svchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/svchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SVCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SVCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsbchc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSBCHC/api/FHIR/R4/",
     "id": "c0ec045c-a3f6-4ec0-acd5-8b4d126c8158",
     "name": "South Boston Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsbchc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsbchc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSBCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSBCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4880,11 +5152,11 @@
     "managingOrganization": "South Central Regional Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartEquityHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTEQUITYHEALTH/api/FHIR/R4/",
     "id": "b8b89562-87c4-4bc4-b494-0aeff84f1bba",
     "name": "South of Market Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartEquityHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartEquityHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTEQUITYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTEQUITYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4912,27 +5184,27 @@
     "managingOrganization": "Southeast Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsjfmc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSJFMC/api/FHIR/R4/",
     "id": "c033b90a-2314-4768-9d0d-db9786163188",
     "name": "Southern Jersey Family Medical Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsjfmc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsjfmc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSJFMC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSJFMC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/SouthsideCHS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SOUTHSIDECHS/api/FHIR/R4/",
     "id": "590219ca-4084-4705-a26a-23a36a30ba94",
     "name": "Southside Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/SouthsideCHS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/SouthsideCHS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SOUTHSIDECHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SOUTHSIDECHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSWCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSWCHC/api/FHIR/R4/",
     "id": "d268845d-cbc0-43a2-8cfe-4299bc1a66c0",
     "name": "Southwest Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSWCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSWCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSWCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSWCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4968,11 +5240,11 @@
     "managingOrganization": "St Luke's University Health Network"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartSA/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSA/api/FHIR/R4/",
     "id": "e162cbf1-6142-4ecc-890b-c5f609479959",
     "name": "St. Anthony's",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartSA/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartSA/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSA/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSA/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -4982,6 +5254,14 @@
     "token": "https://sbhepicrevprox.barnabas.network/FHIRProxy/oauth2/token",
     "authorize": "https://sbhepicrevprox.barnabas.network/FHIRProxy/oauth2/authorize",
     "managingOrganization": "SBH Health System"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "a3064d51-1298-4d60-9c30-7d6da4780706",
+    "name": "St. Croix Health",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://rp.stjude.org/oauth2-prd/api/FHIR/R4/",
@@ -4998,6 +5278,14 @@
     "token": "https://epincoming.slhs.org/Interconnect-FHIR/oauth2/token",
     "authorize": "https://epincoming.slhs.org/Interconnect-FHIR/oauth2/authorize",
     "managingOrganization": "St. Luke's Health System (ID)"
+  },
+  {
+    "url": "https://epicproxy.et0645.epichosted.com/FHIRProxyPRD/MOBILE/api/FHIR/R4/",
+    "id": "c17924ad-84e2-423b-b4bf-2660464b649b",
+    "name": "St. Peter's Health",
+    "token": "https://epicproxy.et0645.epichosted.com/FHIRProxyPRD/MOBILE/oauth2/token",
+    "authorize": "https://epicproxy.et0645.epichosted.com/FHIRProxyPRD/MOBILE/oauth2/authorize",
+    "managingOrganization": "Intermountain Health"
   },
   {
     "url": "https://epicproxy.et1378.epichosted.com/APIProxyPRD/api/FHIR/R4/",
@@ -5024,11 +5312,11 @@
     "managingOrganization": "Stanford Children's Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartsvh/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTSVH/api/FHIR/R4/",
     "id": "2191bf2c-482b-4e86-82bd-d87b11b28598",
     "name": "Star Valley Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartsvh/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartsvh/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTSVH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTSVH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5038,14 +5326,6 @@
     "token": "https://eproxy.mercycare.org/oauth2/STEINDLER/oauth2/token",
     "authorize": "https://eproxy.mercycare.org/oauth2/STEINDLER/oauth2/authorize",
     "managingOrganization": "Mercy Medical Center (IA)"
-  },
-  {
-    "url": "https://epicmobile.centracare.com/fhir/api/FHIR/R4/",
-    "id": "ff01f1e9-258d-4e53-9716-0c40c5a06704",
-    "name": "Stellis Health",
-    "token": "https://epicmobile.centracare.com/fhir/oauth2/token",
-    "authorize": "https://epicmobile.centracare.com/fhir/oauth2/authorize",
-    "managingOrganization": "CentraCare Health System"
   },
   {
     "url": "https://webprd.ochin.org/prd-fhir/HEALTHWELLNSSOKMYCHART/api/FHIR/R4/",
@@ -5129,18 +5409,18 @@
   },
   {
     "url": "https://apiservices.sutterhealth.org/ifs/api/FHIR/R4/",
-    "id": "6be3bca1-13e4-4ca3-b979-fa3857c7bf04",
+    "id": "a827fa04-dd90-eb11-9144-001dd8b71f19",
     "name": "Sutter Health",
     "token": "https://apiservices.sutterhealth.org/ifs/oauth2/token",
     "authorize": "https://apiservices.sutterhealth.org/ifs/oauth2/authorize",
     "managingOrganization": "Sutter Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/syracusecommunityhealthmychart/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/SYRACUSECOMMUNITYHEALTHMYCHART/api/FHIR/R4/",
     "id": "2653bdaf-57f7-43e3-9500-ef96ce707850",
     "name": "Syracuse Community Health",
-    "token": "https://webprd.ochin.org/prd-fhir/syracusecommunityhealthmychart/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/syracusecommunityhealthmychart/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/SYRACUSECOMMUNITYHEALTHMYCHART/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/SYRACUSECOMMUNITYHEALTHMYCHART/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5176,11 +5456,11 @@
     "managingOrganization": "Tanner Health System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartttc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTTTC/api/FHIR/R4/",
     "id": "b4e1118e-c764-47a5-996c-00c64acbb20c",
     "name": "Tarzana Treatment Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartttc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartttc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTTTC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTTTC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5192,16 +5472,16 @@
     "managingOrganization": "Temple Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartTRHS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTTRHS/api/FHIR/R4/",
     "id": "8cca4729-f0cf-4173-bbc1-7b44ed7b3ced",
     "name": "Terry Reilly Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartTRHS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartTRHS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTTRHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTTRHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
     "url": "https://mobileapps.texaschildrens.org/FHIR/api/FHIR/R4/",
-    "id": "d75d1552-ce12-4134-ae11-73a21bda9fdd",
+    "id": "32e28712-b7fa-45f7-b6c3-9ac77b09e85c",
     "name": "Texas Children's",
     "token": "https://mobileapps.texaschildrens.org/FHIR/oauth2/token",
     "authorize": "https://mobileapps.texaschildrens.org/FHIR/oauth2/authorize",
@@ -5232,11 +5512,11 @@
     "managingOrganization": "Scottish Rite for Children"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCHS/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCHS/api/FHIR/R4/",
     "id": "6a800207-a2b2-4262-9329-acd15fe8d168",
     "name": "The Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCHS/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCHS/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCHS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCHS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5249,7 +5529,7 @@
   },
   {
     "url": "https://epicproxy.institute.org/fhir/api/FHIR/R4/",
-    "id": "f00b1b4c-1b7f-4e3a-afa9-000bfb90385c",
+    "id": "0cee72ae-1251-48e5-9881-b472619f96ed",
     "name": "The Institute for Family Health",
     "token": "https://epicproxy.institute.org/fhir/oauth2/token",
     "authorize": "https://epicproxy.institute.org/fhir/oauth2/authorize",
@@ -5288,19 +5568,27 @@
     "managingOrganization": "Jefferson Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mycharttiburcio/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTTIBURCIO/api/FHIR/R4/",
     "id": "d059c006-b7dd-45c8-84b5-0be5658119e4",
     "name": "Tiburcio Vasquez Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mycharttiburcio/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mycharttiburcio/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTTIBURCIO/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTTIBURCIO/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartTillamook/api/FHIR/R4/",
+    "url": "https://eweb.tidalhealth.org/Oauth2/api/FHIR/R4/",
+    "id": "509a57f1-47d4-437d-9a86-7b815c90ae14",
+    "name": "TidalHealth",
+    "token": "https://eweb.tidalhealth.org/Oauth2/oauth2/token",
+    "authorize": "https://eweb.tidalhealth.org/Oauth2/oauth2/authorize",
+    "managingOrganization": "TidalHealth"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTTILLAMOOK/api/FHIR/R4/",
     "id": "6ac2a63f-972d-4e90-a389-8c4193d292bd",
     "name": "Tillamook County Community Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartTillamook/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartTillamook/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTTILLAMOOK/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTTILLAMOOK/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5312,11 +5600,11 @@
     "managingOrganization": "Tower Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/TAPMedicine/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/TAPMEDICINE/api/FHIR/R4/",
     "id": "be0e0f4f-7483-41e5-888d-66274d1e3287",
     "name": "Triad Adult & Pediatric Medicine",
-    "token": "https://webprd.ochin.org/prd-fhir/TAPMedicine/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/TAPMedicine/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/TAPMEDICINE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/TAPMEDICINE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5328,11 +5616,11 @@
     "managingOrganization": "Trinity Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mycharttc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTTC/api/FHIR/R4/",
     "id": "e853045d-75ff-4870-bc68-ffd14a902f09",
     "name": "TrueCare",
-    "token": "https://webprd.ochin.org/prd-fhir/mycharttc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mycharttc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTTC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTTC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5341,7 +5629,7 @@
     "name": "Tucson Independent Physicians and Surgeons",
     "token": "https://fhir.tmcaz.com/FHIRProxy/TIPS/oauth2/token",
     "authorize": "https://fhir.tmcaz.com/FHIRProxy/TIPS/oauth2/authorize",
-    "managingOrganization": "Tucson Medical Center"
+    "managingOrganization": "TMC Health"
   },
   {
     "url": "https://fhir.tmcaz.com/FHIRProxy/api/FHIR/R4/",
@@ -5349,7 +5637,7 @@
     "name": "Tucson Medical Center",
     "token": "https://fhir.tmcaz.com/FHIRProxy/oauth2/token",
     "authorize": "https://fhir.tmcaz.com/FHIRProxy/oauth2/authorize",
-    "managingOrganization": "Tucson Medical Center"
+    "managingOrganization": "TMC Health"
   },
   {
     "url": "https://intconfg-p.well-net.org/PRD-OAUTH2/api/FHIR/R4/",
@@ -5366,6 +5654,14 @@
     "token": "https://epicproxy.ardenthealth.com/fhir/TSSH/oauth2/token",
     "authorize": "https://epicproxy.ardenthealth.com/fhir/TSSH/oauth2/authorize",
     "managingOrganization": "Ardent"
+  },
+  {
+    "url": "https://epicproxy.et1460.epichosted.com/APIPROXYPRD/api/FHIR/R4/",
+    "id": "bf9ecea2-15ee-4db7-a19c-f2d2531f7e5d",
+    "name": "UAB Medicine",
+    "token": "https://epicproxy.et1460.epichosted.com/APIPROXYPRD/oauth2/token",
+    "authorize": "https://epicproxy.et1460.epichosted.com/APIPROXYPRD/oauth2/authorize",
+    "managingOrganization": "UAB Medicine"
   },
   {
     "url": "https://epicproxy.et1448.epichosted.com/APIProxyPRD/api/FHIR/R4/",
@@ -5448,14 +5744,6 @@
     "managingOrganization": "UK HealthCare"
   },
   {
-    "url": "https://arrprd.kdmc.net/fhir/api/FHIR/R4/",
-    "id": "1df83f1c-1f21-4cd4-baad-0302f55a42b5",
-    "name": "UK King's Daughters",
-    "token": "https://arrprd.kdmc.net/fhir/oauth2/token",
-    "authorize": "https://arrprd.kdmc.net/fhir/oauth2/authorize",
-    "managingOrganization": "King's Daughters Health System"
-  },
-  {
     "url": "https://epicproxy.et0978.epichosted.com/FHIRProxy/HOMEPAGE/api/FHIR/R4/",
     "id": "b00a041a-f038-4dcf-bd88-cb8fee29d2ae",
     "name": "UMass Memorial Health",
@@ -5488,19 +5776,19 @@
     "managingOrganization": "UNC Health Care System"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartucfs/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTUCFS/api/FHIR/R4/",
     "id": "1822f4d1-a3c0-4675-ba41-896ffd7c7054",
     "name": "United Community & Family Services Healthcare",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartucfs/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartucfs/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTUCFS/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTUCFS/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/unitedcommunityhealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/UNITEDCOMMUNITYHEALTH/api/FHIR/R4/",
     "id": "78f63f53-0736-4ca8-91aa-beb9210438da",
     "name": "United Community Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/unitedcommunityhealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/unitedcommunityhealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/UNITEDCOMMUNITYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/UNITEDCOMMUNITYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5640,11 +5928,11 @@
     "managingOrganization": "University of Michigan Health-Sparrow"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartCUHCC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTCUHCC/api/FHIR/R4/",
     "id": "29416b68-cbd9-4caf-b767-bb8142e1d35d",
     "name": "University of Minnesota",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartCUHCC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartCUHCC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTCUHCC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTCUHCC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5661,7 +5949,7 @@
     "name": "University of Rochester",
     "token": "https://ercd-sproxy.urmc.rochester.edu/mips/oauth2/token",
     "authorize": "https://ercd-sproxy.urmc.rochester.edu/mips/oauth2/authorize",
-    "managingOrganization": "University of Rochester Medical Center"
+    "managingOrganization": "University of Rochester Medicine"
   },
   {
     "url": "https://epicproxy.et0909.epichosted.com/APIProxyPRD/api/FHIR/R4/",
@@ -5710,6 +5998,14 @@
     "token": "https://epicent-prd-rp.upmc.com/PRD-OAUTH2/oauth2/token",
     "authorize": "https://epicent-prd-rp.upmc.com/PRD-OAUTH2/oauth2/authorize",
     "managingOrganization": "UPMC"
+  },
+  {
+    "url": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/api/FHIR/R4/",
+    "id": "ad457404-60d4-41fc-b9bb-b352078092c9",
+    "name": "Upwell Primary Care",
+    "token": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/token",
+    "authorize": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/authorize",
+    "managingOrganization": "NCH Healthcare System"
   },
   {
     "url": "https://epicproxy.ardenthealth.com/fhir/UTHET/api/FHIR/R4/",
@@ -5784,11 +6080,11 @@
     "managingOrganization": "Valley Children's Hospital"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartvfhc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTVFHC/api/FHIR/R4/",
     "id": "a22a5226-003c-4ff5-9995-4a78dcf6bddc",
     "name": "Valley Family Health Care",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartvfhc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartvfhc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTVFHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTVFHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5840,35 +6136,27 @@
     "managingOrganization": "Vanderbilt University Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartVCHC/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTVCHC/api/FHIR/R4/",
     "id": "1f625a6f-adb8-4fc3-8241-4f20426e350d",
     "name": "Variety Care Health Centers",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartVCHC/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartVCHC/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTVCHC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTVCHC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://epicproxy.et1200.epichosted.com/oauth2-PRD/api/FHIR/R4/",
-    "id": "966634fb-fe2f-488d-a223-8cceca74e064",
-    "name": "VCU Health",
-    "token": "https://epicproxy.et1200.epichosted.com/oauth2-PRD/oauth2/token",
-    "authorize": "https://epicproxy.et1200.epichosted.com/oauth2-PRD/oauth2/authorize",
-    "managingOrganization": "VCU Health"
-  },
-  {
     "url": "https://common.virginiahospitalcenter.com/FHIRPRD/api/FHIR/R4/",
-    "id": "077c3214-d198-4818-b764-a102be5aada8",
+    "id": "2cea908a-cfae-4568-9992-7e2e347fd4b5",
     "name": "VHC Health",
     "token": "https://common.virginiahospitalcenter.com/FHIRPRD/oauth2/token",
     "authorize": "https://common.virginiahospitalcenter.com/FHIRPRD/oauth2/authorize",
     "managingOrganization": "VHC Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartvg/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTVG/api/FHIR/R4/",
     "id": "72285333-ad66-4c7c-a36b-a23b2b008695",
     "name": "Virginia Garcia Memorial Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartvg/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartvg/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTVG/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTVG/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5896,16 +6184,16 @@
     "managingOrganization": "Northwell Health"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartVNAHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTVNAHEALTH/api/FHIR/R4/",
     "id": "b672af8c-75f0-457a-9448-84725781277d",
     "name": "VNA Health Care",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartVNAHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartVNAHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTVNAHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTVNAHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
     "url": "https://haiku.wacofhc.org/FHIR/api/FHIR/R4/",
-    "id": "f20b0f71-9735-4caa-8a24-efbbfbdcdab1",
+    "id": "182ccb34-a20f-46ea-90f0-720391962495",
     "name": "Waco Family Medicine",
     "token": "https://haiku.wacofhc.org/FHIR/oauth2/token",
     "authorize": "https://haiku.wacofhc.org/FHIR/oauth2/authorize",
@@ -5920,11 +6208,11 @@
     "managingOrganization": "WakeMed"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartWallace/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTWALLACE/api/FHIR/R4/",
     "id": "adf96fcb-c89e-408d-8769-6050c99e1aea",
     "name": "Wallace",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartWallace/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartWallace/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTWALLACE/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTWALLACE/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5936,11 +6224,11 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/mychartwc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTWC/api/FHIR/R4/",
     "id": "bda9b45a-1fb6-493e-87fe-740335e9115f",
     "name": "Washington County Public Health",
-    "token": "https://webprd.ochin.org/prd-fhir/mychartwc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/mychartwc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTWC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTWC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5960,11 +6248,11 @@
     "managingOrganization": "Washington Regional Medical Center"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/washoemychart/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/WASHOEMYCHART/api/FHIR/R4/",
     "id": "d0d96fc5-5476-415c-85f0-9c20ffe9da80",
     "name": "Washoe Tribal Health Center",
-    "token": "https://webprd.ochin.org/prd-fhir/washoemychart/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/washoemychart/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/WASHOEMYCHART/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/WASHOEMYCHART/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -5982,6 +6270,14 @@
     "token": "https://epicproxy-pub.et1089.epichosted.com/FHIRProxy/oauth2/token",
     "authorize": "https://epicproxy-pub.et1089.epichosted.com/FHIRProxy/oauth2/authorize",
     "managingOrganization": "New York Consortium"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "5a315020-bebb-4997-9f4d-23f098f4d02a",
+    "name": "Welia Health",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://webprd.ochin.org/prd-fhir/WELLSPACEHEALTHMYCHART/api/FHIR/R4/",
@@ -6008,6 +6304,22 @@
     "managingOrganization": "Garden Plot"
   },
   {
+    "url": "https://epicproxy.et1243.epichosted.com/OAuth2-PRD/api/FHIR/R4/",
+    "id": "af4e1e99-5725-4fbb-86b8-0a330ee0d200",
+    "name": "West Tennessee Healthcare",
+    "token": "https://epicproxy.et1243.epichosted.com/OAuth2-PRD/oauth2/token",
+    "authorize": "https://epicproxy.et1243.epichosted.com/OAuth2-PRD/oauth2/authorize",
+    "managingOrganization": "West Tennessee Healthcare"
+  },
+  {
+    "url": "https://apps.mywvuchart.com/FHIRproxy/api/FHIR/R4/",
+    "id": "e34f333f-8469-4130-b567-9f57f9ec3a77",
+    "name": "West Virginia University",
+    "token": "https://apps.mywvuchart.com/FHIRproxy/oauth2/token",
+    "authorize": "https://apps.mywvuchart.com/FHIRproxy/oauth2/authorize",
+    "managingOrganization": "WVU Medicine"
+  },
+  {
     "url": "https://webprd.ochin.org/prd-fhir/WNCCHS/api/FHIR/R4/",
     "id": "6af6b7ca-e8a1-45cc-9fe7-87e6a38d1907",
     "name": "Western North Carolina Community Health Services",
@@ -6016,12 +6328,20 @@
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartWesternU/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTWESTERNU/api/FHIR/R4/",
     "id": "83dd6afc-a43d-41e4-b0f0-7f6b62a0b5f1",
     "name": "Western University",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartWesternU/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartWesternU/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTWESTERNU/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTWESTERNU/oauth2/authorize",
     "managingOrganization": "OCHIN"
+  },
+  {
+    "url": "https://webproxy.allina.com/FHIR/api/FHIR/R4/",
+    "id": "77e21179-1d23-44db-a54d-4fa089831c57",
+    "name": "Western Wisconsin Health",
+    "token": "https://webproxy.allina.com/FHIR/oauth2/token",
+    "authorize": "https://webproxy.allina.com/FHIR/oauth2/authorize",
+    "managingOrganization": "Allina Health"
   },
   {
     "url": "https://epicproxy.et4001.epichosted.com/APIProxyPRD/WWU/api/FHIR/R4/",
@@ -6032,11 +6352,11 @@
     "managingOrganization": "Garden Plot"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/MyChartWhatleyHealth/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/MYCHARTWHATLEYHEALTH/api/FHIR/R4/",
     "id": "f8cea430-8844-4504-ad4a-94716405183f",
     "name": "Whatley Health Services",
-    "token": "https://webprd.ochin.org/prd-fhir/MyChartWhatleyHealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/MyChartWhatleyHealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/MYCHARTWHATLEYHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/MYCHARTWHATLEYHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
@@ -6048,19 +6368,27 @@
     "managingOrganization": "Memorial Hermann"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/wilmingtoncc/api/FHIR/R4/",
+    "url": "https://webprd.ochin.org/prd-fhir/WILMINGTONCC/api/FHIR/R4/",
     "id": "38e2ce15-652c-4324-b030-05f9fa74836c",
     "name": "Wilmington Community Clinic",
-    "token": "https://webprd.ochin.org/prd-fhir/wilmingtoncc/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/wilmingtoncc/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/WILMINGTONCC/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/WILMINGTONCC/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {
-    "url": "https://webprd.ochin.org/prd-fhir/wintershealth/api/FHIR/R4/",
+    "url": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/api/FHIR/R4/",
+    "id": "6bcead42-cfe8-41da-8601-4ff80e2c51ec",
+    "name": "Winmind Behavioral Health & Addiction Medicine",
+    "token": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/token",
+    "authorize": "https://epicproxy.et1233.epichosted.com/FHIRProxy/AFFILIATE/oauth2/authorize",
+    "managingOrganization": "NCH Healthcare System"
+  },
+  {
+    "url": "https://webprd.ochin.org/prd-fhir/WINTERSHEALTH/api/FHIR/R4/",
     "id": "0e2cccea-dfd8-43c1-9ad3-35d6fdc913f5",
     "name": "Winters Healthcare",
-    "token": "https://webprd.ochin.org/prd-fhir/wintershealth/oauth2/token",
-    "authorize": "https://webprd.ochin.org/prd-fhir/wintershealth/oauth2/authorize",
+    "token": "https://webprd.ochin.org/prd-fhir/WINTERSHEALTH/oauth2/token",
+    "authorize": "https://webprd.ochin.org/prd-fhir/WINTERSHEALTH/oauth2/authorize",
     "managingOrganization": "OCHIN"
   },
   {


### PR DESCRIPTION
Refresh of the Epic R4 endpoint list via the fetchMetadata script (`npx tsx fetchMetadata.ts --r4`).

Notable additions include a second Intermountain Health-managed endpoint (St. Peter's Health), plus a large batch of OCHIN-hosted tenants. Also documents Epic's plain R4 endpoint list URL in `.env.example`.